### PR TITLE
Add pytest-based tests and CI workflow

### DIFF
--- a/.github/workflows/format-and-run.yml
+++ b/.github/workflows/format-and-run.yml
@@ -40,4 +40,9 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git add app
           git commit -m "Format Python code with Black" || echo "No changes to commit"
-          git push
+          # Only push if there are changes and GITHUB_HEAD_REF is set (i.e., on PRs)
+          if [ -n "$GITHUB_HEAD_REF" ]; then
+            git push origin HEAD:$GITHUB_HEAD_REF
+          else
+            git push || echo "Not a PR, or no branch to push to."
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+            python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: ./.coverage
+          if-no-files-found: ignore

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -q --cov=app --cov-report=term-missing
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,6 @@ uvloop
 watchfiles
 websockets
 PyYAML
+pytest
+pytest-cov
+httpx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    download_dir = tmp_path / "downloads"
+    monkeypatch.setenv("DATA_DIR", str(data_dir))
+    monkeypatch.setenv("DOWNLOAD_DIR", str(download_dir))
+
+    repo_root = Path(__file__).resolve().parents[1]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    import types, argparse
+
+    stub_parser = types.ModuleType("aniworld.parser")
+    stub_parser.parse_arguments = lambda: argparse.Namespace()
+    stub_parser.arguments = argparse.Namespace()
+    sys.modules["aniworld.parser"] = stub_parser
+
+    from sqlmodel import SQLModel
+
+    SQLModel.metadata.clear()
+
+    modules = [
+        "app.config",
+        "app.models",
+        "app.torznab",
+        "app.qbittorrent",
+        "app.main",
+    ]
+    for m in modules:
+        if m in sys.modules:
+            del sys.modules[m]
+
+    from app.main import app
+    from app.models import create_db_and_tables
+    import app.qbittorrent as qb
+
+    create_db_and_tables()
+
+    monkeypatch.setattr(qb, "schedule_download", lambda req: "job-1")
+    monkeypatch.setattr(qb, "cancel_job", lambda job_id: None)
+
+    with TestClient(app) as c:
+        yield c

--- a/tests/test_qbittorrent_auth.py
+++ b/tests/test_qbittorrent_auth.py
@@ -1,0 +1,12 @@
+def test_login_and_basic_endpoints(client):
+    resp = client.post("/api/v2/auth/login", data={"username": "u", "password": "p"})
+    assert resp.status_code == 200
+    assert resp.cookies.get("SID") == "anibridge"
+
+    pref = client.get("/api/v2/app/preferences")
+    assert pref.status_code == 200
+    assert "save_path" in pref.json()
+
+    cats = client.get("/api/v2/torrents/categories")
+    assert cats.status_code == 200
+    assert "prowlarr" in cats.json()

--- a/tests/test_qbittorrent_torrents.py
+++ b/tests/test_qbittorrent_torrents.py
@@ -1,0 +1,32 @@
+def test_torrent_lifecycle(client):
+    from app.magnet import build_magnet
+
+    resp = client.post(
+        "/api/v2/torrents/createCategory",
+        data={"category": "anime", "savePath": "/tmp"},
+    )
+    assert resp.status_code == 200
+
+    magnet = build_magnet(
+        title="Title",
+        slug="slug",
+        season=1,
+        episode=1,
+        language="German Dub",
+    )
+    add = client.post(
+        "/api/v2/torrents/add", data={"urls": magnet, "category": "anime"}
+    )
+    assert add.status_code == 200
+
+    info = client.get("/api/v2/torrents/info")
+    items = info.json()
+    assert len(items) == 1
+    assert items[0]["state"] == "downloading"
+    h = items[0]["hash"]
+
+    del_resp = client.post("/api/v2/torrents/delete", data={"hashes": h})
+    assert del_resp.status_code == 200
+
+    info2 = client.get("/api/v2/torrents/info")
+    assert info2.json() == []

--- a/tests/test_title_resolver.py
+++ b/tests/test_title_resolver.py
@@ -1,0 +1,11 @@
+def test_build_index_from_html():
+    from app.title_resolver import build_index_from_html
+
+    html = """
+    <html><body>
+    <a href="/anime/stream/slug-one">Title One</a>
+    <a href="/anime/stream/slug-two">Title Two</a>
+    </body></html>
+    """
+    index = build_index_from_html(html)
+    assert index == {"slug-one": "Title One", "slug-two": "Title Two"}

--- a/tests/test_torznab.py
+++ b/tests/test_torznab.py
@@ -1,0 +1,67 @@
+import xml.etree.ElementTree as ET
+
+
+def test_caps(client):
+    resp = client.get("/torznab/api", params={"t": "caps"})
+    assert resp.status_code == 200
+    ET.fromstring(resp.text)
+
+
+def test_search(client):
+    resp = client.get("/torznab/api", params={"t": "search", "q": "test"})
+    assert resp.status_code == 200
+    root = ET.fromstring(resp.text)
+    assert root.find("channel") is not None
+
+
+def test_tvsearch_happy_path(client, monkeypatch):
+    import app.torznab as tn
+
+    class Rec:
+        available = True
+        is_fresh = True
+        height = 1080
+        vcodec = "h264"
+        provider = "prov"
+
+    monkeypatch.setattr(tn, "_slug_from_query", lambda q: "slug")
+    monkeypatch.setattr(tn, "resolve_series_title", lambda slug: "Series")
+    monkeypatch.setattr(
+        tn,
+        "list_available_languages_cached",
+        lambda session, slug, season, episode: ["German Dub"],
+    )
+    monkeypatch.setattr(
+        tn,
+        "get_availability",
+        lambda session, slug, season, episode, language: Rec(),
+    )
+    monkeypatch.setattr(
+        tn,
+        "build_release_name",
+        lambda series_title, season, episode, height, vcodec, language: "Title",
+    )
+    monkeypatch.setattr(
+        tn,
+        "build_magnet",
+        lambda title, slug, season, episode, language, provider: "magnet:?xt=urn:btih:test&dn=Title&aw_slug=slug&aw_s=1&aw_e=1&aw_lang=German+Dub",
+    )
+
+    resp = client.get(
+        "/torznab/api",
+        params={"t": "tvsearch", "q": "foo", "season": 1, "ep": 1},
+    )
+    assert resp.status_code == 200
+    root = ET.fromstring(resp.text)
+    item = root.find("./channel/item")
+    assert item is not None
+    seed = item.find("{http://torznab.com/schemas/2015/feed}attr[@name='seeders']")
+    leech = item.find("{http://torznab.com/schemas/2015/feed}attr[@name='leechers']")
+    assert seed is not None and leech is not None
+
+
+def test_tvsearch_empty(client):
+    resp = client.get("/torznab/api", params={"t": "tvsearch", "q": "foo"})
+    assert resp.status_code == 200
+    root = ET.fromstring(resp.text)
+    assert root.find("./channel/item") is None


### PR DESCRIPTION
## Summary
- set up pytest with coverage configuration
- add unit and integration tests for Torznab and qBittorrent endpoints
- add GitHub Actions workflow to run tests and publish coverage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f583d401c8324a83ae17a73ef6e4c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added extensive tests for authentication, torrent lifecycle, Torznab API (caps/search/tvsearch), and title resolution.
  - Added a reusable test client fixture and isolated test environment setup.
  - Configured pytest defaults for quiet output and coverage reporting; added test dependencies.

- Chores
  - Added CI workflow to run tests on pushes and pull requests and upload coverage artifacts.
  - Improved an existing CI workflow to handle PR vs non-PR pushes more safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->