### PR TITLE
Episode and Torrent timestamps reflect publish date of provider

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -14,6 +14,7 @@ AniBridge is a minimal FastAPI service that bridges anime and series streaming c
 
 - **Torznab endpoint** that indexes available episodes from AniWorld, Serienstream (s.to), and megakino.
 - **qBittorrent API shim** allowing Prowlarr/Sonarr to enqueue downloads.
+- **Release-aware timestamps** for AniWorld and s.to where available (`pubDate` and synthetic torrent `added_on` use provider publish time instead of request time).
 - **Background scheduler** with progress tracking for downloads.
 - **STRM files and STRM proxy** support for stable streaming URLs.
 - Simple `/health` endpoint for container or orchestration checks.

--- a/app/api/qbittorrent/sync.py
+++ b/app/api/qbittorrent/sync.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from fastapi import Depends
 from fastapi.responses import JSONResponse
 from loguru import logger
@@ -10,6 +11,14 @@ from app.db import get_session, get_job
 from . import router
 from .common import CATEGORIES, public_save_path
 from app.config import DOWNLOAD_DIR, QBIT_PUBLIC_SAVE_PATH
+
+
+def _to_utc_timestamp(dt: datetime) -> int:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return int(dt.timestamp())
 
 
 @router.get("/sync/maindata")
@@ -50,7 +59,7 @@ def sync_maindata(session: Session = Depends(get_session)):
             except Exception:
                 pass
 
-        completion_ts = int((r.completion_on or r.added_on).timestamp())
+        completion_ts = _to_utc_timestamp(r.completion_on or r.added_on)
         if job and job.status == "completed":
             if job.result_path and os.path.exists(job.result_path):
                 try:
@@ -64,7 +73,7 @@ def sync_maindata(session: Session = Depends(get_session)):
                     session.commit()
                 except Exception:
                     session.rollback()
-                completion_ts = int(r.completion_on.timestamp())
+                completion_ts = _to_utc_timestamp(r.completion_on)
 
         dlspeed_val = int(job.speed or 0) if job else 0
         if job and job.status == "completed":
@@ -79,7 +88,7 @@ def sync_maindata(session: Session = Depends(get_session)):
             "category": r.category or "",
             "save_path": save_path_val,
             "size": size_val,
-            "added_on": int(r.added_on.timestamp()),
+            "added_on": _to_utc_timestamp(r.added_on),
             "completion_on": completion_ts,
         }
 
@@ -94,7 +103,3 @@ def sync_maindata(session: Session = Depends(get_session)):
             "categories": CATEGORIES,
         }
     )
-
-
-# Required imports for datetime after function since we used it above
-from datetime import datetime, timezone  # noqa: E402

--- a/app/api/qbittorrent/sync.py
+++ b/app/api/qbittorrent/sync.py
@@ -14,6 +14,15 @@ from app.config import DOWNLOAD_DIR, QBIT_PUBLIC_SAVE_PATH
 
 
 def _to_utc_timestamp(dt: datetime) -> int:
+    """
+    Normalize a datetime to UTC and return its Unix timestamp in seconds.
+    
+    Parameters:
+        dt (datetime): The datetime to normalize. If `dt` has no timezone information it is treated as UTC; if it has a timezone it is converted to UTC.
+    
+    Returns:
+        int: Unix timestamp (seconds since the Unix epoch) of the UTC-normalized datetime.
+    """
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
     else:
@@ -23,7 +32,18 @@ def _to_utc_timestamp(dt: datetime) -> int:
 
 @router.get("/sync/maindata")
 def sync_maindata(session: Session = Depends(get_session)):
-    """Minimal maindata dump accepted by Sonarr."""
+    """
+    Produce a minimal maindata payload compatible with Sonarr containing torrents and categories.
+    
+    Builds a torrents mapping from database ClientTask rows (augmented with related job information when available) and returns a JSONResponse structured to match Sonarr's expected maindata format.
+    
+    Returns:
+        JSONResponse: A response with keys:
+            - rid: request id (int)
+            - server_state: dict with connection_status and dht_nodes
+            - torrents: dict mapping torrent hash to metadata (name, progress, state, dlspeed, eta, category, save_path, size, added_on, completion_on)
+            - categories: list of available categories
+    """
     logger.debug("Sync maindata requested.")
     from sqlmodel import select
     from app.db import ClientTask

--- a/app/api/qbittorrent/sync.py
+++ b/app/api/qbittorrent/sync.py
@@ -10,24 +10,8 @@ from app.db import get_session, get_job
 
 from . import router
 from .common import CATEGORIES, public_save_path
+from .utils import _to_utc_timestamp
 from app.config import DOWNLOAD_DIR, QBIT_PUBLIC_SAVE_PATH
-
-
-def _to_utc_timestamp(dt: datetime) -> int:
-    """
-    Normalize a datetime to UTC and return its Unix timestamp in seconds.
-
-    Parameters:
-        dt (datetime): The datetime to normalize. If `dt` has no timezone information it is treated as UTC; if it has a timezone it is converted to UTC.
-
-    Returns:
-        int: Unix timestamp (seconds since the Unix epoch) of the UTC-normalized datetime.
-    """
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    else:
-        dt = dt.astimezone(timezone.utc)
-    return int(dt.timestamp())
 
 
 @router.get("/sync/maindata")

--- a/app/api/qbittorrent/sync.py
+++ b/app/api/qbittorrent/sync.py
@@ -16,10 +16,10 @@ from app.config import DOWNLOAD_DIR, QBIT_PUBLIC_SAVE_PATH
 def _to_utc_timestamp(dt: datetime) -> int:
     """
     Normalize a datetime to UTC and return its Unix timestamp in seconds.
-    
+
     Parameters:
         dt (datetime): The datetime to normalize. If `dt` has no timezone information it is treated as UTC; if it has a timezone it is converted to UTC.
-    
+
     Returns:
         int: Unix timestamp (seconds since the Unix epoch) of the UTC-normalized datetime.
     """
@@ -34,9 +34,9 @@ def _to_utc_timestamp(dt: datetime) -> int:
 def sync_maindata(session: Session = Depends(get_session)):
     """
     Produce a minimal maindata payload compatible with Sonarr containing torrents and categories.
-    
+
     Builds a torrents mapping from database ClientTask rows (augmented with related job information when available) and returns a JSONResponse structured to match Sonarr's expected maindata format.
-    
+
     Returns:
         JSONResponse: A response with keys:
             - rid: request id (int)

--- a/app/api/qbittorrent/torrents.py
+++ b/app/api/qbittorrent/torrents.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import List, Optional
 
 from fastapi import Depends, Form, HTTPException, Request
@@ -27,23 +26,7 @@ from app.utils.release_dates import release_at_from_extra
 
 from . import router
 from .common import public_save_path
-
-
-def _to_utc_timestamp(dt: datetime) -> int:
-    """
-    Convert a datetime to a UTC Unix timestamp.
-
-    Parameters:
-        dt (datetime): A naive or timezone-aware datetime. If naive, it is treated as UTC; if timezone-aware, it is converted to UTC.
-
-    Returns:
-        int: Unix timestamp in seconds since the UTC epoch.
-    """
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    else:
-        dt = dt.astimezone(timezone.utc)
-    return int(dt.timestamp())
+from .utils import _to_utc_timestamp
 
 
 @router.post("/torrents/add")

--- a/app/api/qbittorrent/torrents.py
+++ b/app/api/qbittorrent/torrents.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import List, Optional
 
 from fastapi import Depends, Form, HTTPException, Request
@@ -19,11 +20,21 @@ from app.db import (
     get_client_task,
     delete_client_task,
     get_job,
+    get_availability,
 )
 from app.core.scheduler import schedule_download, cancel_job
+from app.utils.release_dates import release_at_from_extra
 
 from . import router
 from .common import public_save_path
+
+
+def _to_utc_timestamp(dt: datetime) -> int:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return int(dt.timestamp())
 
 
 @router.post("/torrents/add")
@@ -107,6 +118,28 @@ def torrents_add(
     if not savepath:
         savepath = str(DOWNLOAD_DIR)
     published_savepath = QBIT_PUBLIC_SAVE_PATH or savepath
+    added_on = None
+    try:
+        availability = get_availability(
+            session,
+            slug=slug,
+            season=season,
+            episode=episode,
+            language=language,
+            site=site,
+        )
+        if availability is not None:
+            added_on = release_at_from_extra(availability.extra)
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        logger.debug(
+            "Could not resolve release timestamp for {} S{}E{} {} on {}: {}",
+            slug,
+            season,
+            episode,
+            language,
+            site,
+            exc,
+        )
 
     upsert_client_task(
         session,
@@ -121,6 +154,7 @@ def torrents_add(
         category=category,
         job_id=job_id,
         state="queued" if paused else "downloading",
+        added_on=added_on,
     )
     logger.success(
         "Torrent task upserted for hash={}, state={}, site={}".format(
@@ -206,8 +240,8 @@ def torrents_info(
                 "category": r.category or "",
                 "save_path": save_path_val,
                 "content_path": content_path or "",
-                "added_on": int(r.added_on.timestamp()),
-                "completion_on": int((r.completion_on or r.added_on).timestamp()),
+                "added_on": _to_utc_timestamp(r.added_on),
+                "completion_on": _to_utc_timestamp(r.completion_on or r.added_on),
                 "size": int(size or 0),
                 "num_seeds": 0,
                 "num_leechs": 0,
@@ -287,8 +321,8 @@ def torrents_properties(session: Session = Depends(get_session), hash: str = "")
         total_size = int(job.total_bytes)
 
     now = int(time.time())
-    addition_date = int(rec.added_on.timestamp())
-    completion_date = int((rec.completion_on or rec.added_on).timestamp())
+    addition_date = _to_utc_timestamp(rec.added_on)
+    completion_date = _to_utc_timestamp(rec.completion_on or rec.added_on)
     seeding_time = max(0, now - completion_date) if rec.completion_on else 0
     time_elapsed = max(0, now - addition_date)
 

--- a/app/api/qbittorrent/torrents.py
+++ b/app/api/qbittorrent/torrents.py
@@ -30,6 +30,15 @@ from .common import public_save_path
 
 
 def _to_utc_timestamp(dt: datetime) -> int:
+    """
+    Convert a datetime to a UTC Unix timestamp.
+    
+    Parameters:
+        dt (datetime): A naive or timezone-aware datetime. If naive, it is treated as UTC; if timezone-aware, it is converted to UTC.
+    
+    Returns:
+        int: Unix timestamp in seconds since the UTC epoch.
+    """
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
     else:
@@ -170,7 +179,18 @@ def torrents_info(
     filter: Optional[str] = None,
     category: Optional[str] = None,
 ):
-    """List torrents (ClientTasks) in qBittorrent-compatible subset."""
+    """
+    Produce a qBittorrent-compatible list of client tasks and their current status.
+    
+    Parameters:
+        filter (Optional[str]): Optional filter string (currently unused).
+        category (Optional[str]): If provided, include only tasks whose category exactly matches this value.
+    
+    Returns:
+        JSONResponse: A JSON array of objects describing each torrent. Each object contains:
+            hash, name, state, progress, dlspeed, upspeed, eta, category, save_path,
+            content_path, added_on, completion_on, size, num_seeds, num_leechs.
+    """
     logger.debug("Fetching torrents info.")
     from sqlmodel import select
     from app.db import ClientTask
@@ -296,7 +316,21 @@ def torrents_files(session: Session = Depends(get_session), hash: str = ""):
 
 @router.get("/torrents/properties")
 def torrents_properties(session: Session = Depends(get_session), hash: str = ""):
-    """Minimal /torrents/properties implementation used by Sonarr after completion."""
+    """
+    Return torrent property information expected by Sonarr for a completed or in-progress torrent.
+    
+    Parameters:
+        hash (str): Torrent info-hash (case-insensitive); required.
+    
+    Returns:
+        dict: JSON-serializable mapping of torrent properties (e.g., save_path, creation_date, piece_size, total_downloaded, time_elapsed, seeding_time, addition_date, completion_date, created_by).
+    
+    Raises:
+        HTTPException: 400 if `hash` is missing or empty; 404 if no matching client task is found.
+    
+    Notes:
+        - `creation_date`, `addition_date`, and `completion_date` are UTC Unix timestamps.
+    """
     import os
     import time
 

--- a/app/api/qbittorrent/torrents.py
+++ b/app/api/qbittorrent/torrents.py
@@ -32,10 +32,10 @@ from .common import public_save_path
 def _to_utc_timestamp(dt: datetime) -> int:
     """
     Convert a datetime to a UTC Unix timestamp.
-    
+
     Parameters:
         dt (datetime): A naive or timezone-aware datetime. If naive, it is treated as UTC; if timezone-aware, it is converted to UTC.
-    
+
     Returns:
         int: Unix timestamp in seconds since the UTC epoch.
     """
@@ -181,11 +181,11 @@ def torrents_info(
 ):
     """
     Produce a qBittorrent-compatible list of client tasks and their current status.
-    
+
     Parameters:
         filter (Optional[str]): Optional filter string (currently unused).
         category (Optional[str]): If provided, include only tasks whose category exactly matches this value.
-    
+
     Returns:
         JSONResponse: A JSON array of objects describing each torrent. Each object contains:
             hash, name, state, progress, dlspeed, upspeed, eta, category, save_path,
@@ -318,16 +318,16 @@ def torrents_files(session: Session = Depends(get_session), hash: str = ""):
 def torrents_properties(session: Session = Depends(get_session), hash: str = ""):
     """
     Return torrent property information expected by Sonarr for a completed or in-progress torrent.
-    
+
     Parameters:
         hash (str): Torrent info-hash (case-insensitive); required.
-    
+
     Returns:
         dict: JSON-serializable mapping of torrent properties (e.g., save_path, creation_date, piece_size, total_downloaded, time_elapsed, seeding_time, addition_date, completion_date, created_by).
-    
+
     Raises:
         HTTPException: 400 if `hash` is missing or empty; 404 if no matching client task is found.
-    
+
     Notes:
         - `creation_date`, `addition_date`, and `completion_date` are UTC Unix timestamps.
     """

--- a/app/api/qbittorrent/utils.py
+++ b/app/api/qbittorrent/utils.py
@@ -6,6 +6,10 @@ from datetime import datetime, timezone
 def _to_utc_timestamp(dt: datetime) -> int:
     """Convert a datetime to a UTC POSIX timestamp integer.
 
+    Parameters:
+        dt (datetime): Datetime to convert; naive datetimes are treated as UTC,
+        aware datetimes are converted to UTC.
+
     Naive datetimes are treated as UTC by assigning `timezone.utc`. Aware
     datetimes are converted to UTC via `astimezone(timezone.utc)`.
 

--- a/app/api/qbittorrent/utils.py
+++ b/app/api/qbittorrent/utils.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def _to_utc_timestamp(dt: datetime) -> int:
+    """Convert a datetime to a UTC POSIX timestamp integer.
+
+    Naive datetimes are treated as UTC by assigning `timezone.utc`. Aware
+    datetimes are converted to UTC via `astimezone(timezone.utc)`.
+
+    Returns:
+        int: POSIX timestamp in whole seconds.
+
+    Raises:
+        TypeError: If `dt` is `None` or not a datetime instance.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return int(dt.timestamp())

--- a/app/api/qbittorrent/utils.py
+++ b/app/api/qbittorrent/utils.py
@@ -13,8 +13,10 @@ def _to_utc_timestamp(dt: datetime) -> int:
         int: POSIX timestamp in whole seconds.
 
     Raises:
-        TypeError: If `dt` is `None` or not a datetime instance.
+        TypeError: If `dt` is not a datetime instance.
     """
+    if not isinstance(dt, datetime):
+        raise TypeError("dt must be a datetime instance")
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
     else:

--- a/app/api/torznab/__init__.py
+++ b/app/api/torznab/__init__.py
@@ -43,6 +43,7 @@ from app.db import (  # noqa: E402
     list_cached_episode_numbers_for_season,
     upsert_availability,
 )
+from app.utils.release_dates import RELEASE_AT_EXTRA_KEY  # noqa: E402
 
 __all__ = [
     "router",
@@ -69,4 +70,5 @@ __all__ = [
     "list_available_languages_cached",
     "list_cached_episode_numbers_for_season",
     "upsert_availability",
+    "RELEASE_AT_EXTRA_KEY",
 ]

--- a/app/api/torznab/api.py
+++ b/app/api/torznab/api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 import xml.etree.ElementTree as ET
 import threading
 import time
@@ -125,8 +125,8 @@ def _ordered_unique(values: List[str]) -> List[str]:
 
 def _resolve_release_at(
     *,
-    rec_extra: object = None,
-    probe_info: object = None,
+    rec_extra: Optional[Dict[str, Any]] = None,
+    probe_info: Optional[Dict[str, Any]] = None,
 ) -> Optional[datetime]:
     """
     Derives a release datetime from probe information or record extra metadata.
@@ -134,8 +134,8 @@ def _resolve_release_at(
     Checks the provided probe_info for a release timestamp and returns it if present; if not found, attempts to extract a release timestamp from rec_extra.
 
     Parameters:
-        rec_extra (object): Record extra metadata (e.g., availability/alias metadata) that may contain a release timestamp.
-        probe_info (object): Probe result metadata that may include a release timestamp.
+        rec_extra (Optional[Dict[str, Any]]): Record extra metadata (e.g., availability/alias metadata) that may contain a release timestamp.
+        probe_info (Optional[Dict[str, Any]]): Probe result metadata that may include a release timestamp.
 
     Returns:
         Optional[datetime]: A datetime representing the release time if present in probe_info or rec_extra, otherwise `None`.
@@ -146,8 +146,8 @@ def _resolve_release_at(
 def _resolve_pubdate(
     *,
     default_now: datetime,
-    rec_extra: object = None,
-    probe_info: object = None,
+    rec_extra: Optional[Dict[str, Any]] = None,
+    probe_info: Optional[Dict[str, Any]] = None,
 ) -> datetime:
     """
     Choose a publication datetime for an item, preferring a resolved release timestamp when available.
@@ -156,8 +156,8 @@ def _resolve_pubdate(
 
     Parameters:
         default_now (datetime): Fallback datetime to use when no release timestamp is found.
-        rec_extra (object, optional): Stored record extra metadata that may contain release information.
-        probe_info (object, optional): Probe result information that may contain release information.
+        rec_extra (Optional[Dict[str, Any]], optional): Stored record extra metadata that may contain release information.
+        probe_info (Optional[Dict[str, Any]], optional): Probe result information that may contain release information.
 
     Returns:
         datetime: The resolved publication datetime — the release timestamp if present, otherwise `default_now`.
@@ -169,20 +169,20 @@ def _resolve_pubdate(
 
 def _merge_extra_with_release(
     *,
-    base_extra: Optional[dict],
-    rec_extra: object = None,
-    probe_info: object = None,
-) -> Optional[dict]:
+    base_extra: Optional[Dict[str, Any]],
+    rec_extra: Optional[Dict[str, Any]] = None,
+    probe_info: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
     """
     Return a copy of `base_extra` augmented with a derived `release_at` timestamp when available.
 
     Parameters:
-        base_extra (Optional[dict]): Base extra metadata to merge into. If `None`, no base metadata is available.
-        rec_extra (object): Record extra metadata that may contain a release timestamp or related hints.
-        probe_info (object): Probe result object that may include a release timestamp key.
+        base_extra (Optional[Dict[str, Any]]): Base extra metadata to merge into. If `None`, no base metadata is available.
+        rec_extra (Optional[Dict[str, Any]]): Record extra metadata that may contain a release timestamp or related hints.
+        probe_info (Optional[Dict[str, Any]]): Probe result object that may include a release timestamp key.
 
     Returns:
-        Optional[dict]: A dictionary containing the merged metadata. If a release time can be derived from `rec_extra` or `probe_info`,
+        Optional[Dict[str, Any]]: A dictionary containing the merged metadata. If a release time can be derived from `rec_extra` or `probe_info`,
         the result will include a `release_at` entry; otherwise the result is `base_extra` (or `None` if `base_extra` was `None`).
     """
     return merge_extra_with_release_at(

--- a/app/api/torznab/api.py
+++ b/app/api/torznab/api.py
@@ -119,7 +119,9 @@ class TNModuleProtocol(Protocol):
         preferred_provider: Optional[str] = None,
         timeout: float = 6.0,
         site: str = "aniworld.to",
-    ) -> tuple[bool, Optional[int], Optional[str], Optional[str], Optional[Dict[str, Any]]]: ...
+    ) -> tuple[
+        bool, Optional[int], Optional[str], Optional[str], Optional[Dict[str, Any]]
+    ]: ...
 
 
 def _default_languages_for_site(site: str) -> List[str]:

--- a/app/api/torznab/api.py
+++ b/app/api/torznab/api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, NamedTuple, Optional
 import xml.etree.ElementTree as ET
 import threading
 import time
@@ -55,6 +55,20 @@ _TVSEARCH_ID_CACHE_MAX_ENTRIES = 512
 _TVSEARCH_SKYHOOK_CACHE_LOCK = threading.Lock()
 _TVSEARCH_TERM_TO_TVDB_CACHE: dict[str, tuple[float, int]] = {}
 _TVSEARCH_TVDB_TO_TITLE_CACHE: dict[int, tuple[float, str]] = {}
+
+
+class ProbeResult(NamedTuple):
+    """Structured mapped-special probe result."""
+
+    success: bool
+    mapped_id: Optional[int]
+    mapped_name: Optional[str]
+    mapped_type: Optional[str]
+    count_a: int
+    count_b: int
+    count_c: int
+    count_d: int
+    timestamp: Optional[datetime]
 
 
 def _default_languages_for_site(site: str) -> List[str]:
@@ -719,17 +733,7 @@ def _try_mapped_special_probe(
     lang: str,
     site_found: str,
     special_map,
-) -> tuple[
-    bool,
-    Optional[int],
-    Optional[str],
-    Optional[str],
-    int,
-    int,
-    int,
-    int,
-    Optional[datetime],
-]:
+) -> ProbeResult:
     """
     Probe availability and quality for an AniWorld special that maps to a different source episode and return availability, quality metadata, mapping coordinates, and an optional release timestamp.
 
@@ -742,17 +746,8 @@ def _try_mapped_special_probe(
         special_map: Object with `source_season`, `source_episode`, `alias_season`, and `alias_episode` describing the mapping.
 
     Returns:
-        tuple: (
-            available (bool): True if the mapped source episode is available, False otherwise,
-            height (Optional[int]): reported video height in pixels, or `None` if unknown,
-            vcodec (Optional[str]): reported video codec identifier, or `None` if unknown,
-            provider (Optional[str]): provider name that supplied quality info, or `None`,
-            source_season (int): season number of the mapped source episode,
-            source_episode (int): episode number of the mapped source episode,
-            alias_season (int): alias (requested) season number,
-            alias_episode (int): alias (requested) episode number,
-            release_at (Optional[datetime]): UTC release timestamp when available, otherwise `None`
-        )
+        ProbeResult: Structured probe result containing availability, quality
+        metadata, mapped source and alias coordinates, and optional release time.
     """
     source_season = special_map.source_season
     source_episode = special_map.source_episode
@@ -771,16 +766,16 @@ def _try_mapped_special_probe(
     except (ValueError, RuntimeError):
         rec_mapped = None
     if rec_mapped and rec_mapped.available and rec_mapped.is_fresh:
-        return (
-            True,
-            rec_mapped.height,
-            rec_mapped.vcodec,
-            rec_mapped.provider,
-            source_season,
-            source_episode,
-            alias_season,
-            alias_episode,
-            release_at_from_extra(rec_mapped.extra),
+        return ProbeResult(
+            success=True,
+            mapped_id=rec_mapped.height,
+            mapped_name=rec_mapped.vcodec,
+            mapped_type=rec_mapped.provider,
+            count_a=source_season,
+            count_b=source_episode,
+            count_c=alias_season,
+            count_d=alias_episode,
+            timestamp=release_at_from_extra(rec_mapped.extra),
         )
 
     try:
@@ -807,16 +802,16 @@ def _try_mapped_special_probe(
         prov_used = None
         info = None
 
-    return (
-        available,
-        height,
-        vcodec,
-        prov_used,
-        source_season,
-        source_episode,
-        alias_season,
-        alias_episode,
-        release_at_from_probe_info(info),
+    return ProbeResult(
+        success=available,
+        mapped_id=height,
+        mapped_name=vcodec,
+        mapped_type=prov_used,
+        count_a=source_season,
+        count_b=source_episode,
+        count_c=alias_season,
+        count_d=alias_episode,
+        timestamp=release_at_from_probe_info(info),
     )
 
 
@@ -1039,17 +1034,7 @@ def emit_tvsearch_episode_items(
                                 special_map.source_episode,
                             )
                     if special_map is not None:
-                        (
-                            available,
-                            height,
-                            vcodec,
-                            prov_used,
-                            source_season,
-                            source_episode,
-                            alias_season,
-                            alias_episode,
-                            mapped_release_at,
-                        ) = _try_mapped_special_probe(
+                        mapped_probe = _try_mapped_special_probe(
                             tn_module=tn_module,
                             session=session,
                             slug=slug,
@@ -1057,6 +1042,15 @@ def emit_tvsearch_episode_items(
                             site_found=site_found,
                             special_map=special_map,
                         )
+                        available = mapped_probe.success
+                        height = mapped_probe.mapped_id
+                        vcodec = mapped_probe.mapped_name
+                        prov_used = mapped_probe.mapped_type
+                        source_season = mapped_probe.count_a
+                        source_episode = mapped_probe.count_b
+                        alias_season = mapped_probe.count_c
+                        alias_episode = mapped_probe.count_d
+                        mapped_release_at = mapped_probe.timestamp
                         if mapped_release_at is not None:
                             item_pubdate = mapped_release_at
                             info = {

--- a/app/api/torznab/api.py
+++ b/app/api/torznab/api.py
@@ -108,9 +108,9 @@ def _coerce_non_negative_int(value: object) -> Optional[int]:
 def _ordered_unique(values: List[str]) -> List[str]:
     """
     Produce a list of unique, non-empty strings from the input while preserving their original order.
-    
+
     Returns:
-    	list (List[str]): The input values converted to trimmed strings with empty values removed and duplicates dropped, preserving first-occurrence order.
+        list (List[str]): The input values converted to trimmed strings with empty values removed and duplicates dropped, preserving first-occurrence order.
     """
     out: List[str] = []
     seen: set[str] = set()
@@ -130,13 +130,13 @@ def _resolve_release_at(
 ) -> Optional[datetime]:
     """
     Derives a release datetime from probe information or record extra metadata.
-    
+
     Checks the provided probe_info for a release timestamp and returns it if present; if not found, attempts to extract a release timestamp from rec_extra.
-    
+
     Parameters:
         rec_extra (object): Record extra metadata (e.g., availability/alias metadata) that may contain a release timestamp.
         probe_info (object): Probe result metadata that may include a release timestamp.
-    
+
     Returns:
         Optional[datetime]: A datetime representing the release time if present in probe_info or rec_extra, otherwise `None`.
     """
@@ -151,14 +151,14 @@ def _resolve_pubdate(
 ) -> datetime:
     """
     Choose a publication datetime for an item, preferring a resolved release timestamp when available.
-    
+
     Inspects provided record extra metadata and probe information for a release timestamp. If a release timestamp is found, that value is returned; otherwise returns the supplied default_now.
-    
+
     Parameters:
         default_now (datetime): Fallback datetime to use when no release timestamp is found.
         rec_extra (object, optional): Stored record extra metadata that may contain release information.
         probe_info (object, optional): Probe result information that may contain release information.
-    
+
     Returns:
         datetime: The resolved publication datetime — the release timestamp if present, otherwise `default_now`.
     """
@@ -175,12 +175,12 @@ def _merge_extra_with_release(
 ) -> Optional[dict]:
     """
     Return a copy of `base_extra` augmented with a derived `release_at` timestamp when available.
-    
+
     Parameters:
         base_extra (Optional[dict]): Base extra metadata to merge into. If `None`, no base metadata is available.
         rec_extra (object): Record extra metadata that may contain a release timestamp or related hints.
         probe_info (object): Probe result object that may include a release timestamp key.
-    
+
     Returns:
         Optional[dict]: A dictionary containing the merged metadata. If a release time can be derived from `rec_extra` or `probe_info`,
         the result will include a `release_at` entry; otherwise the result is `base_extra` (or `None` if `base_extra` was `None`).
@@ -194,7 +194,7 @@ def _merge_extra_with_release(
 def _cache_get_term_tvdb(term: str) -> Optional[int]:
     """
     Get the cached TVDB ID for a SkyHook search term if the cache entry is still valid.
-    
+
     Returns:
         The cached TVDB ID if present and not expired, `None` otherwise.
     """
@@ -525,10 +525,10 @@ def _probe_episode_available_for_discovery(
 ) -> bool:
     """
     Determine whether the specified episode is available in at least one candidate language.
-    
+
     This checks cached availability first and, if not fresh, probes providers for quality/availability.
     Probe results are upserted into the availability store (via tn_module.upsert_availability), so this function has a side effect of persisting discovered availability and metadata.
-    
+
     Parameters:
         tn_module: Provider module implementing list_available_languages_cached, get_availability,
             probe_episode_quality, and upsert_availability.
@@ -537,7 +537,7 @@ def _probe_episode_available_for_discovery(
         season_i (int): Season number.
         episode_i (int): Episode number.
         site_found (str): Catalogue/site identifier to scope language discovery and probes.
-    
+
     Returns:
         bool: `true` if the episode is found available in any candidate language, `false` otherwise.
     """
@@ -732,7 +732,7 @@ def _try_mapped_special_probe(
 ]:
     """
     Probe availability and quality for an AniWorld special that maps to a different source episode and return availability, quality metadata, mapping coordinates, and an optional release timestamp.
-    
+
     Parameters:
         tn_module: Provider module offering `get_availability` and `probe_episode_quality`.
         session (Session): Database/session used by `get_availability`.
@@ -740,7 +740,7 @@ def _try_mapped_special_probe(
         lang (str): Language code or label to probe (e.g., "German Dub").
         site_found (str): Catalogue site where the mapped source episode is hosted.
         special_map: Object with `source_season`, `source_episode`, `alias_season`, and `alias_episode` describing the mapping.
-    
+
     Returns:
         tuple: (
             available (bool): True if the mapped source episode is available, False otherwise,
@@ -840,9 +840,9 @@ def emit_tvsearch_episode_items(
 ) -> tuple[int, bool]:
     """
     Emit RSS items for a single TV episode request (season/episode) into the provided channel.
-    
+
     Emits magnet and optional STRM items for available languages, upserts availability records via the provided tn_module, and uses cached, discovered, or live-probed quality information to determine availability, release metadata, and pubdate. Iteration respects max_items and STRM_FILES_MODE and may consult special-episode mappings for certain sites.
-    
+
     Parameters:
         tn_module: Provider module exposing availability, probing, magnet and title builders, and upsert functions.
         session: Database/session object used by tn_module for cache reads and upserts.
@@ -859,7 +859,7 @@ def emit_tvsearch_episode_items(
         max_items: Optional maximum number of RSS items to emit; when reached, emission stops.
         allow_live_probe: If true, the function may perform live provider probes for quality/availability.
         fast_episode_languages: Optional prediscovered candidate languages to prefer before probing.
-    
+
     Returns:
         tuple[int, bool]: The number of RSS items emitted and a boolean indicating whether
         emission stopped because max_items was reached.
@@ -1231,7 +1231,7 @@ def _handle_preview_search(
 ) -> int:
     """
     Add preview (S01E01) search results for the given query to the provided RSS channel.
-    
+
     Parameters:
         session (Session): Database/session object used for availability lookups and upserts.
         q_str (str): Query string to resolve into a series slug.
@@ -1240,7 +1240,7 @@ def _handle_preview_search(
         site (Optional[str]): Optional site identifier to constrain slug resolution and provider selection.
         limit (Optional[int]): Maximum number of items to add; None means no explicit limit.
         strm_suffix (str): Suffix appended to release titles for STRM entries (default: " [STRM]").
-    
+
     Returns:
         int: Number of items added to the channel.
     """
@@ -1400,9 +1400,9 @@ def _handle_special_search(
 ) -> int:
     """
     Generate RSS items for title-only queries that map to AniWorld "special" episodes via metadata aliasing.
-    
+
     Appends episode-specific RSS items whose displayed season/episode (alias SxxEyy) is for Sonarr while the torrent/magnet targets the mapped AniWorld source season/episode. For each candidate language the function probes availability, upserts availability with alias metadata, and creates magnet and optional STRM items until the optional limit is reached.
-    
+
     Parameters:
         session (Session): Database/session used for cached lookups and availability upserts.
         q_str (str): Title-only query string to resolve.
@@ -1411,7 +1411,7 @@ def _handle_special_search(
         ids (SpecialIds): Identifiers (tvdb/tmdb/imdb/rid/tvmaze) used to assist special-mapping resolution.
         limit (Optional[int]): Maximum number of RSS items to add; None means no explicit limit.
         strm_suffix (str): Suffix appended to release titles for STRM-mode items.
-    
+
     Returns:
         int: Number of RSS items added to the provided channel.
     """

--- a/app/api/torznab/api.py
+++ b/app/api/torznab/api.py
@@ -106,7 +106,12 @@ def _coerce_non_negative_int(value: object) -> Optional[int]:
 
 
 def _ordered_unique(values: List[str]) -> List[str]:
-    """Return de-duplicated, non-empty strings while preserving original order."""
+    """
+    Produce a list of unique, non-empty strings from the input while preserving their original order.
+    
+    Returns:
+    	list (List[str]): The input values converted to trimmed strings with empty values removed and duplicates dropped, preserving first-occurrence order.
+    """
     out: List[str] = []
     seen: set[str] = set()
     for raw in values:
@@ -123,6 +128,18 @@ def _resolve_release_at(
     rec_extra: object = None,
     probe_info: object = None,
 ) -> Optional[datetime]:
+    """
+    Derives a release datetime from probe information or record extra metadata.
+    
+    Checks the provided probe_info for a release timestamp and returns it if present; if not found, attempts to extract a release timestamp from rec_extra.
+    
+    Parameters:
+        rec_extra (object): Record extra metadata (e.g., availability/alias metadata) that may contain a release timestamp.
+        probe_info (object): Probe result metadata that may include a release timestamp.
+    
+    Returns:
+        Optional[datetime]: A datetime representing the release time if present in probe_info or rec_extra, otherwise `None`.
+    """
     return release_at_from_probe_info(probe_info) or release_at_from_extra(rec_extra)
 
 
@@ -132,6 +149,19 @@ def _resolve_pubdate(
     rec_extra: object = None,
     probe_info: object = None,
 ) -> datetime:
+    """
+    Choose a publication datetime for an item, preferring a resolved release timestamp when available.
+    
+    Inspects provided record extra metadata and probe information for a release timestamp. If a release timestamp is found, that value is returned; otherwise returns the supplied default_now.
+    
+    Parameters:
+        default_now (datetime): Fallback datetime to use when no release timestamp is found.
+        rec_extra (object, optional): Stored record extra metadata that may contain release information.
+        probe_info (object, optional): Probe result information that may contain release information.
+    
+    Returns:
+        datetime: The resolved publication datetime — the release timestamp if present, otherwise `default_now`.
+    """
     return (
         _resolve_release_at(rec_extra=rec_extra, probe_info=probe_info) or default_now
     )
@@ -143,6 +173,18 @@ def _merge_extra_with_release(
     rec_extra: object = None,
     probe_info: object = None,
 ) -> Optional[dict]:
+    """
+    Return a copy of `base_extra` augmented with a derived `release_at` timestamp when available.
+    
+    Parameters:
+        base_extra (Optional[dict]): Base extra metadata to merge into. If `None`, no base metadata is available.
+        rec_extra (object): Record extra metadata that may contain a release timestamp or related hints.
+        probe_info (object): Probe result object that may include a release timestamp key.
+    
+    Returns:
+        Optional[dict]: A dictionary containing the merged metadata. If a release time can be derived from `rec_extra` or `probe_info`,
+        the result will include a `release_at` entry; otherwise the result is `base_extra` (or `None` if `base_extra` was `None`).
+    """
     return merge_extra_with_release_at(
         base_extra=base_extra,
         release_at=_resolve_release_at(rec_extra=rec_extra, probe_info=probe_info),
@@ -150,7 +192,12 @@ def _merge_extra_with_release(
 
 
 def _cache_get_term_tvdb(term: str) -> Optional[int]:
-    """Return cached tvdb id for a SkyHook search term when entry is fresh."""
+    """
+    Get the cached TVDB ID for a SkyHook search term if the cache entry is still valid.
+    
+    Returns:
+        The cached TVDB ID if present and not expired, `None` otherwise.
+    """
     now = time.time()
     with _TVSEARCH_SKYHOOK_CACHE_LOCK:
         entry = _TVSEARCH_TERM_TO_TVDB_CACHE.get(term)
@@ -477,7 +524,22 @@ def _probe_episode_available_for_discovery(
     site_found: str,
 ) -> bool:
     """
-    Probe whether an episode is available in at least one candidate language.
+    Determine whether the specified episode is available in at least one candidate language.
+    
+    This checks cached availability first and, if not fresh, probes providers for quality/availability.
+    Probe results are upserted into the availability store (via tn_module.upsert_availability), so this function has a side effect of persisting discovered availability and metadata.
+    
+    Parameters:
+        tn_module: Provider module implementing list_available_languages_cached, get_availability,
+            probe_episode_quality, and upsert_availability.
+        session: Database/session object used by tn_module for cached reads and upserts.
+        slug (str): Series identifier.
+        season_i (int): Season number.
+        episode_i (int): Episode number.
+        site_found (str): Catalogue/site identifier to scope language discovery and probes.
+    
+    Returns:
+        bool: `true` if the episode is found available in any candidate language, `false` otherwise.
     """
     cached_langs = tn_module.list_available_languages_cached(
         session,
@@ -669,27 +731,27 @@ def _try_mapped_special_probe(
     Optional[datetime],
 ]:
     """
-    Probe availability and quality for an AniWorld special that maps to a different source episode, using cached availability when possible.
-
+    Probe availability and quality for an AniWorld special that maps to a different source episode and return availability, quality metadata, mapping coordinates, and an optional release timestamp.
+    
     Parameters:
-        tn_module: Provider module exposing `get_availability` and `probe_episode_quality` used to fetch cached availability or probe live quality.
-        session (Session): Database/session object used by `get_availability`.
+        tn_module: Provider module offering `get_availability` and `probe_episode_quality`.
+        session (Session): Database/session used by `get_availability`.
         slug (str): Show identifier used for probing.
-        lang (str): Language to probe (e.g., "German Dub").
-        site_found (str): Catalogue site name where the source episode is hosted.
-        special_map: Mapping object containing `source_season`, `source_episode`, `alias_season`, and `alias_episode` that describe the source coordinates and their alias.
-
+        lang (str): Language code or label to probe (e.g., "German Dub").
+        site_found (str): Catalogue site where the mapped source episode is hosted.
+        special_map: Object with `source_season`, `source_episode`, `alias_season`, and `alias_episode` describing the mapping.
+    
     Returns:
         tuple: (
-            available (bool): `True` if the source episode is available, `False` otherwise,
-            height (Optional[int]): video height in pixels if known, otherwise `None`,
-            vcodec (Optional[str]): video codec identifier if known, otherwise `None`,
-            provider (Optional[str]): provider name that supplied the quality info if known, otherwise `None`,
+            available (bool): True if the mapped source episode is available, False otherwise,
+            height (Optional[int]): reported video height in pixels, or `None` if unknown,
+            vcodec (Optional[str]): reported video codec identifier, or `None` if unknown,
+            provider (Optional[str]): provider name that supplied quality info, or `None`,
             source_season (int): season number of the mapped source episode,
             source_episode (int): episode number of the mapped source episode,
-            alias_season (int): alias season number requested,
-            alias_episode (int): alias episode number requested,
-            release_at (Optional[datetime]): parsed release timestamp in UTC when available
+            alias_season (int): alias (requested) season number,
+            alias_episode (int): alias (requested) episode number,
+            release_at (Optional[datetime]): UTC release timestamp when available, otherwise `None`
         )
     """
     source_season = special_map.source_season
@@ -777,12 +839,30 @@ def emit_tvsearch_episode_items(
     fast_episode_languages: Optional[List[str]] = None,
 ) -> tuple[int, bool]:
     """
-    Emit tvsearch RSS items for one requested season/episode pair.
-
+    Emit RSS items for a single TV episode request (season/episode) into the provided channel.
+    
+    Emits magnet and optional STRM items for available languages, upserts availability records via the provided tn_module, and uses cached, discovered, or live-probed quality information to determine availability, release metadata, and pubdate. Iteration respects max_items and STRM_FILES_MODE and may consult special-episode mappings for certain sites.
+    
+    Parameters:
+        tn_module: Provider module exposing availability, probing, magnet and title builders, and upsert functions.
+        session: Database/session object used by tn_module for cache reads and upserts.
+        channel: XML channel element to which RSS item elements will be appended.
+        slug: Series identifier/slug to query and emit items for.
+        site_found: Source site identifier used for lookups and item metadata (e.g., "aniworld.to").
+        display_title: Human-readable series title used when building release names.
+        q_str: Original query string used for potential special-episode mappings and logging.
+        request_season: Requested season number.
+        request_episode: Requested episode number.
+        ids: Supplemental identifier bundle (e.g., tvdb/tmdb/imdb) used for mapping/probing.
+        now: Fallback publication datetime used when no release timestamp is available.
+        strm_suffix: Suffix appended to titles when building STRM-mode magnet entries.
+        max_items: Optional maximum number of RSS items to emit; when reached, emission stops.
+        allow_live_probe: If true, the function may perform live provider probes for quality/availability.
+        fast_episode_languages: Optional prediscovered candidate languages to prefer before probing.
+    
     Returns:
-        tuple[int, bool]:
-            - Number of emitted RSS items.
-            - Whether emission stopped because the provided `max_items` was reached.
+        tuple[int, bool]: The number of RSS items emitted and a boolean indicating whether
+        emission stopped because max_items was reached.
     """
     cached_langs = tn_module.list_available_languages_cached(
         session,
@@ -1150,15 +1230,17 @@ def _handle_preview_search(
     strm_suffix: str = " [STRM]",
 ) -> int:
     """
-    Populate the RSS channel with preview (S01E01) search results for the given query.
-
-    Resolves the query to a series slug (optionally constrained by site), determines candidate languages, probes and upserts preview availability per language, constructs magnet (and optional STRM) links according to STRM_FILES_MODE, and adds corresponding RSS items to the provided channel.
-
+    Add preview (S01E01) search results for the given query to the provided RSS channel.
+    
     Parameters:
-        site (Optional[str]): Optional site identifier to constrain slug resolution and source-specific behavior.
+        session (Session): Database/session object used for availability lookups and upserts.
+        q_str (str): Query string to resolve into a series slug.
+        channel (xml.etree.ElementTree.Element): RSS channel element to append items to.
+        cat_id (int): Category ID to set on created RSS items.
+        site (Optional[str]): Optional site identifier to constrain slug resolution and provider selection.
         limit (Optional[int]): Maximum number of items to add; None means no explicit limit.
         strm_suffix (str): Suffix appended to release titles for STRM entries (default: " [STRM]").
-
+    
     Returns:
         int: Number of items added to the channel.
     """
@@ -1317,19 +1399,19 @@ def _handle_special_search(
     strm_suffix: str = " [STRM]",
 ) -> int:
     """
-    Generate RSS items for title-only searches that map to AniWorld "special" episodes using metadata-backed aliasing.
-
-    When the query resolves to an aniworld.to slug and a special mapping exists, this will add episode-specific RSS items whose displayed release title uses the Sonarr-facing alias season/episode (SxxEyy) while the magnet payload targets the AniWorld source season/episode. For each candidate language it probes availability, upserts availability with alias metadata, and creates magnet and optional STRM items according to STRM_FILES_MODE. Processing stops when the optional limit is reached.
-
+    Generate RSS items for title-only queries that map to AniWorld "special" episodes via metadata aliasing.
+    
+    Appends episode-specific RSS items whose displayed season/episode (alias SxxEyy) is for Sonarr while the torrent/magnet targets the mapped AniWorld source season/episode. For each candidate language the function probes availability, upserts availability with alias metadata, and creates magnet and optional STRM items until the optional limit is reached.
+    
     Parameters:
-        session (Session): Database/session object used for cached lookups and upserts.
+        session (Session): Database/session used for cached lookups and availability upserts.
         q_str (str): Title-only query string to resolve.
         channel (xml.etree.ElementTree.Element): RSS channel element to which items will be appended.
-        cat_id (int): Torznab category id to use for generated items.
+        cat_id (int): Torznab category id to assign to generated items.
         ids (SpecialIds): Identifiers (tvdb/tmdb/imdb/rid/tvmaze) used to assist special-mapping resolution.
         limit (Optional[int]): Maximum number of RSS items to add; None means no explicit limit.
         strm_suffix (str): Suffix appended to release titles for STRM-mode items.
-
+    
     Returns:
         int: Number of RSS items added to the provided channel.
     """

--- a/app/api/torznab/api.py
+++ b/app/api/torznab/api.py
@@ -38,6 +38,12 @@ from app.providers.aniworld.specials import (
 from app.utils.magnet import _site_prefix
 from app.utils.movie_year import get_movie_year
 from app.utils.http_client import get as http_get
+from app.utils.release_dates import (
+    PROBE_INFO_RELEASE_AT_KEY,
+    merge_extra_with_release_at,
+    release_at_from_extra,
+    release_at_from_probe_info,
+)
 
 from . import router
 from .utils import _build_item, _caps_xml, _require_apikey, _rss_root
@@ -110,6 +116,37 @@ def _ordered_unique(values: List[str]) -> List[str]:
         seen.add(item)
         out.append(item)
     return out
+
+
+def _resolve_release_at(
+    *,
+    rec_extra: object = None,
+    probe_info: object = None,
+) -> Optional[datetime]:
+    return release_at_from_probe_info(probe_info) or release_at_from_extra(rec_extra)
+
+
+def _resolve_pubdate(
+    *,
+    default_now: datetime,
+    rec_extra: object = None,
+    probe_info: object = None,
+) -> datetime:
+    return (
+        _resolve_release_at(rec_extra=rec_extra, probe_info=probe_info) or default_now
+    )
+
+
+def _merge_extra_with_release(
+    *,
+    base_extra: Optional[dict],
+    rec_extra: object = None,
+    probe_info: object = None,
+) -> Optional[dict]:
+    return merge_extra_with_release_at(
+        base_extra=base_extra,
+        release_at=_resolve_release_at(rec_extra=rec_extra, probe_info=probe_info),
+    )
 
 
 def _cache_get_term_tvdb(term: str) -> Optional[int]:
@@ -468,7 +505,7 @@ def _probe_episode_available_for_discovery(
             return True
 
         try:
-            available, height, vcodec, prov_used, _info = (
+            available, height, vcodec, prov_used, info = (
                 tn_module.probe_episode_quality(
                     slug=slug,
                     season=season_i,
@@ -482,6 +519,7 @@ def _probe_episode_available_for_discovery(
             height = None
             vcodec = None
             prov_used = None
+            info = None
 
         try:
             tn_module.upsert_availability(
@@ -494,7 +532,11 @@ def _probe_episode_available_for_discovery(
                 height=height,
                 vcodec=vcodec,
                 provider=prov_used,
-                extra=None,
+                extra=_merge_extra_with_release(
+                    base_extra=None,
+                    rec_extra=getattr(rec, "extra", None),
+                    probe_info=info,
+                ),
                 site=site_found,
             )
         except (ValueError, RuntimeError):
@@ -615,7 +657,17 @@ def _try_mapped_special_probe(
     lang: str,
     site_found: str,
     special_map,
-) -> tuple[bool, Optional[int], Optional[str], Optional[str], int, int, int, int]:
+) -> tuple[
+    bool,
+    Optional[int],
+    Optional[str],
+    Optional[str],
+    int,
+    int,
+    int,
+    int,
+    Optional[datetime],
+]:
     """
     Probe availability and quality for an AniWorld special that maps to a different source episode, using cached availability when possible.
 
@@ -636,7 +688,8 @@ def _try_mapped_special_probe(
             source_season (int): season number of the mapped source episode,
             source_episode (int): episode number of the mapped source episode,
             alias_season (int): alias season number requested,
-            alias_episode (int): alias episode number requested
+            alias_episode (int): alias episode number requested,
+            release_at (Optional[datetime]): parsed release timestamp in UTC when available
         )
     """
     source_season = special_map.source_season
@@ -665,10 +718,11 @@ def _try_mapped_special_probe(
             source_episode,
             alias_season,
             alias_episode,
+            release_at_from_extra(rec_mapped.extra),
         )
 
     try:
-        available, height, vcodec, prov_used, _info = tn_module.probe_episode_quality(
+        available, height, vcodec, prov_used, info = tn_module.probe_episode_quality(
             slug=slug,
             season=source_season,
             episode=source_episode,
@@ -689,6 +743,7 @@ def _try_mapped_special_probe(
         height = None
         vcodec = None
         prov_used = None
+        info = None
 
     return (
         available,
@@ -699,6 +754,7 @@ def _try_mapped_special_probe(
         source_episode,
         alias_season,
         alias_episode,
+        release_at_from_probe_info(info),
     )
 
 
@@ -801,12 +857,18 @@ def emit_tvsearch_episode_items(
         height = None
         vcodec = None
         prov_used = None
+        info = None
+        item_pubdate = now
 
         if rec and rec.available and rec.is_fresh:
             available = True
             height = rec.height
             vcodec = rec.vcodec
             prov_used = rec.provider
+            item_pubdate = _resolve_pubdate(
+                default_now=now,
+                rec_extra=getattr(rec, "extra", None),
+            )
             logger.debug(
                 (
                     "Using cached availability for {} S{}E{} {} on {}: "
@@ -828,6 +890,10 @@ def emit_tvsearch_episode_items(
                     height = rec.height
                     vcodec = rec.vcodec
                     prov_used = rec.provider
+                    item_pubdate = _resolve_pubdate(
+                        default_now=now,
+                        rec_extra=getattr(rec, "extra", None),
+                    )
                 elif discovered_fast_languages and lang in discovered_fast_languages:
                     available = True
                     height = None
@@ -837,7 +903,7 @@ def emit_tvsearch_episode_items(
                     available = False
             else:
                 try:
-                    available, height, vcodec, prov_used, _info = (
+                    available, height, vcodec, prov_used, info = (
                         tn_module.probe_episode_quality(
                             slug=slug,
                             season=source_season,
@@ -857,6 +923,13 @@ def emit_tvsearch_episode_items(
                         e,
                     )
                     available = False
+                    info = None
+
+                item_pubdate = _resolve_pubdate(
+                    default_now=now,
+                    rec_extra=getattr(rec, "extra", None),
+                    probe_info=info,
+                )
 
                 if (
                     not available
@@ -895,6 +968,7 @@ def emit_tvsearch_episode_items(
                             source_episode,
                             alias_season,
                             alias_episode,
+                            mapped_release_at,
                         ) = _try_mapped_special_probe(
                             tn_module=tn_module,
                             session=session,
@@ -903,6 +977,11 @@ def emit_tvsearch_episode_items(
                             site_found=site_found,
                             special_map=special_map,
                         )
+                        if mapped_release_at is not None:
+                            item_pubdate = mapped_release_at
+                            info = {
+                                PROBE_INFO_RELEASE_AT_KEY: mapped_release_at.isoformat()
+                            }
 
                 try:
                     tn_module.upsert_availability(
@@ -915,13 +994,17 @@ def emit_tvsearch_episode_items(
                         height=height,
                         vcodec=vcodec,
                         provider=prov_used,
-                        extra=(
-                            {
-                                "special_alias_season": alias_season,
-                                "special_alias_episode": alias_episode,
-                            }
-                            if special_map is not None
-                            else None
+                        extra=_merge_extra_with_release(
+                            base_extra=(
+                                {
+                                    "special_alias_season": alias_season,
+                                    "special_alias_episode": alias_episode,
+                                }
+                                if special_map is not None
+                                else None
+                            ),
+                            rec_extra=getattr(rec, "extra", None),
+                            probe_info=info,
                         ),
                         site=site_found,
                     )
@@ -1010,7 +1093,7 @@ def emit_tvsearch_episode_items(
                     channel=channel,
                     title=release_title,
                     magnet=magnet,
-                    pubdate=now,
+                    pubdate=item_pubdate,
                     cat_id=TORZNAB_CAT_ANIME,
                     guid_str=guid_base,
                     language=lang,
@@ -1033,7 +1116,7 @@ def emit_tvsearch_episode_items(
                     channel=channel,
                     title=release_title + strm_suffix,
                     magnet=magnet_strm,
-                    pubdate=now,
+                    pubdate=item_pubdate,
                     cat_id=TORZNAB_CAT_ANIME,
                     guid_str=f"{guid_base}:strm",
                     language=lang,
@@ -1113,7 +1196,7 @@ def _handle_preview_search(
 
     for lang in candidate_langs:
         try:
-            available, h, vc, prov, _info = tn.probe_episode_quality(
+            available, h, vc, prov, info = tn.probe_episode_quality(
                 slug=slug,
                 season=season_i,
                 episode=ep_i,
@@ -1138,7 +1221,10 @@ def _handle_preview_search(
                 height=h,
                 vcodec=vc,
                 provider=prov,
-                extra=None,
+                extra=_merge_extra_with_release(
+                    base_extra=None,
+                    probe_info=info,
+                ),
                 site=site_found,
             )
         except (ValueError, RuntimeError) as e:
@@ -1149,6 +1235,7 @@ def _handle_preview_search(
             )
         if not available:
             continue
+        item_pubdate = _resolve_pubdate(default_now=now, probe_info=info)
 
         # Preview results omit SxxEyy in the release title, but we keep S01E01
         # placeholders in the magnet metadata for backward compatibility.
@@ -1183,7 +1270,7 @@ def _handle_preview_search(
                     channel=channel,
                     title=release_title,
                     magnet=magnet,
-                    pubdate=now,
+                    pubdate=item_pubdate,
                     cat_id=cat_id,
                     guid_str=guid_base,
                     language=lang,
@@ -1203,7 +1290,7 @@ def _handle_preview_search(
                     channel=channel,
                     title=release_title + strm_suffix,
                     magnet=magnet_strm,
-                    pubdate=now,
+                    pubdate=item_pubdate,
                     cat_id=cat_id,
                     guid_str=f"{guid_base}:strm",
                     language=lang,
@@ -1300,7 +1387,7 @@ def _handle_special_search(
 
     for lang in candidate_langs:
         try:
-            available, h, vc, prov, _info = tn.probe_episode_quality(
+            available, h, vc, prov, info = tn.probe_episode_quality(
                 slug=slug,
                 season=target_season,
                 episode=target_episode,
@@ -1329,10 +1416,13 @@ def _handle_special_search(
                 height=h,
                 vcodec=vc,
                 provider=prov,
-                extra={
-                    "special_alias_season": alias_season,
-                    "special_alias_episode": alias_episode,
-                },
+                extra=_merge_extra_with_release(
+                    base_extra={
+                        "special_alias_season": alias_season,
+                        "special_alias_episode": alias_episode,
+                    },
+                    probe_info=info,
+                ),
                 site=site_found,
             )
         except (ValueError, RuntimeError) as e:
@@ -1347,6 +1437,7 @@ def _handle_special_search(
             )
         if not available:
             continue
+        item_pubdate = _resolve_pubdate(default_now=now, probe_info=info)
 
         release_title = tn.build_release_name(
             series_title=display_title,
@@ -1385,7 +1476,7 @@ def _handle_special_search(
                     channel=channel,
                     title=release_title,
                     magnet=magnet,
-                    pubdate=now,
+                    pubdate=item_pubdate,
                     cat_id=cat_id,
                     guid_str=guid_base,
                     language=lang,
@@ -1405,7 +1496,7 @@ def _handle_special_search(
                     channel=channel,
                     title=release_title + strm_suffix,
                     magnet=magnet_strm,
-                    pubdate=now,
+                    pubdate=item_pubdate,
                     cat_id=cat_id,
                     guid_str=f"{guid_base}:strm",
                     language=lang,

--- a/app/api/torznab/api.py
+++ b/app/api/torznab/api.py
@@ -58,16 +58,28 @@ _TVSEARCH_TVDB_TO_TITLE_CACHE: dict[int, tuple[float, str]] = {}
 
 
 class ProbeResult(NamedTuple):
-    """Structured mapped-special probe result."""
+    """Structured mapped-special probe result.
+
+    Fields:
+        success (bool): Whether mapped probing determined the episode is available.
+        height_px (Optional[int]): Reported video height in pixels.
+        codec (Optional[str]): Reported video codec.
+        provider (Optional[str]): Provider used for the mapped probe.
+        src_season (int): Source season used for probing.
+        src_episode (int): Source episode used for probing.
+        alias_season (int): Alias season requested by the client.
+        alias_episode (int): Alias episode requested by the client.
+        timestamp (Optional[datetime]): Resolved UTC release timestamp, if available.
+    """
 
     success: bool
-    mapped_id: Optional[int]
-    mapped_name: Optional[str]
-    mapped_type: Optional[str]
-    count_a: int
-    count_b: int
-    count_c: int
-    count_d: int
+    height_px: Optional[int]
+    codec: Optional[str]
+    provider: Optional[str]
+    src_season: int
+    src_episode: int
+    alias_season: int
+    alias_episode: int
     timestamp: Optional[datetime]
 
 
@@ -768,13 +780,13 @@ def _try_mapped_special_probe(
     if rec_mapped and rec_mapped.available and rec_mapped.is_fresh:
         return ProbeResult(
             success=True,
-            mapped_id=rec_mapped.height,
-            mapped_name=rec_mapped.vcodec,
-            mapped_type=rec_mapped.provider,
-            count_a=source_season,
-            count_b=source_episode,
-            count_c=alias_season,
-            count_d=alias_episode,
+            height_px=rec_mapped.height,
+            codec=rec_mapped.vcodec,
+            provider=rec_mapped.provider,
+            src_season=source_season,
+            src_episode=source_episode,
+            alias_season=alias_season,
+            alias_episode=alias_episode,
             timestamp=release_at_from_extra(rec_mapped.extra),
         )
 
@@ -804,13 +816,13 @@ def _try_mapped_special_probe(
 
     return ProbeResult(
         success=available,
-        mapped_id=height,
-        mapped_name=vcodec,
-        mapped_type=prov_used,
-        count_a=source_season,
-        count_b=source_episode,
-        count_c=alias_season,
-        count_d=alias_episode,
+        height_px=height,
+        codec=vcodec,
+        provider=prov_used,
+        src_season=source_season,
+        src_episode=source_episode,
+        alias_season=alias_season,
+        alias_episode=alias_episode,
         timestamp=release_at_from_probe_info(info),
     )
 
@@ -1043,13 +1055,13 @@ def emit_tvsearch_episode_items(
                             special_map=special_map,
                         )
                         available = mapped_probe.success
-                        height = mapped_probe.mapped_id
-                        vcodec = mapped_probe.mapped_name
-                        prov_used = mapped_probe.mapped_type
-                        source_season = mapped_probe.count_a
-                        source_episode = mapped_probe.count_b
-                        alias_season = mapped_probe.count_c
-                        alias_episode = mapped_probe.count_d
+                        height = mapped_probe.height_px
+                        vcodec = mapped_probe.codec
+                        prov_used = mapped_probe.provider
+                        source_season = mapped_probe.src_season
+                        source_episode = mapped_probe.src_episode
+                        alias_season = mapped_probe.alias_season
+                        alias_episode = mapped_probe.alias_episode
                         mapped_release_at = mapped_probe.timestamp
                         if mapped_release_at is not None:
                             item_pubdate = mapped_release_at

--- a/app/api/torznab/api.py
+++ b/app/api/torznab/api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, Dict, List, NamedTuple, Optional
+from typing import Any, Dict, List, NamedTuple, Optional, Protocol
 import xml.etree.ElementTree as ET
 import threading
 import time
@@ -32,6 +32,7 @@ from app.config import (
 from app.db import get_session
 from app.providers.aniworld.specials import (
     SpecialIds,
+    SpecialEpisodeMapping,
     resolve_special_mapping_from_episode_request,
     resolve_special_mapping_from_query,
 )
@@ -81,6 +82,44 @@ class ProbeResult(NamedTuple):
     alias_season: int
     alias_episode: int
     timestamp: Optional[datetime]
+
+
+class AvailabilityRecordProtocol(Protocol):
+    """Shape of cached availability records used by mapped-special probing."""
+
+    available: bool
+    is_fresh: bool
+    height: Optional[int]
+    vcodec: Optional[str]
+    provider: Optional[str]
+    extra: Optional[Dict[str, Any]]
+
+
+class TNModuleProtocol(Protocol):
+    """Required tn-module interface for mapped-special probe operations."""
+
+    def get_availability(
+        self,
+        session: Session,
+        *,
+        slug: str,
+        season: int,
+        episode: int,
+        language: str,
+        site: str = "aniworld.to",
+    ) -> Optional[AvailabilityRecordProtocol]: ...
+
+    def probe_episode_quality(
+        self,
+        *,
+        slug: str,
+        season: int,
+        episode: int,
+        language: str,
+        preferred_provider: Optional[str] = None,
+        timeout: float = 6.0,
+        site: str = "aniworld.to",
+    ) -> tuple[bool, Optional[int], Optional[str], Optional[str], Optional[Dict[str, Any]]]: ...
 
 
 def _default_languages_for_site(site: str) -> List[str]:
@@ -211,8 +250,14 @@ def _merge_extra_with_release(
         Optional[Dict[str, Any]]: A dictionary containing the merged metadata. If a release time can be derived from `rec_extra` or `probe_info`,
         the result will include a `release_at` entry; otherwise the result is `base_extra` (or `None` if `base_extra` was `None`).
     """
+    merged_extra: Dict[str, Any] = {}
+    if isinstance(base_extra, dict):
+        merged_extra.update(base_extra)
+    if isinstance(rec_extra, dict):
+        merged_extra.update(rec_extra)
+
     return merge_extra_with_release_at(
-        base_extra=base_extra,
+        base_extra=merged_extra or None,
         release_at=_resolve_release_at(rec_extra=rec_extra, probe_info=probe_info),
     )
 
@@ -739,12 +784,12 @@ def resolve_season_episode_numbers(
 
 def _try_mapped_special_probe(
     *,
-    tn_module,
+    tn_module: TNModuleProtocol,
     session: Session,
     slug: str,
     lang: str,
     site_found: str,
-    special_map,
+    special_map: SpecialEpisodeMapping,
 ) -> ProbeResult:
     """
     Probe availability and quality for an AniWorld special that maps to a different source episode and return availability, quality metadata, mapping coordinates, and an optional release timestamp.

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -702,13 +702,12 @@ def upsert_client_task(
     added_on: Optional[datetime] = None,
 ) -> ClientTask:
     """
-    Insert or update a ClientTask record identified by its hash.
-
+    Create or update a ClientTask record identified by its hash.
+    
     Parameters:
-        hash (str): Unique identifier for the client task (primary key).
-        site (str): Site identifier to store on the record; defaults to "aniworld.to".
-        added_on (Optional[datetime]): Optional timestamp override used for the synthetic torrent's creation/add date.
-
+        hash (str): Primary key identifying the client task.
+        added_on (Optional[datetime]): If provided, used as the task's creation/add date; converted to aware UTC. If omitted on insert, the current UTC time is used. On update, the stored `added_on` is changed only when this argument is provided.
+    
     Returns:
         ClientTask: The persisted ClientTask instance refreshed from the database.
     """

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -699,6 +699,7 @@ def upsert_client_task(
     job_id: Optional[str],
     state: str = "queued",
     site: str = "aniworld.to",
+    added_on: Optional[datetime] = None,
 ) -> ClientTask:
     """
     Insert or update a ClientTask record identified by its hash.
@@ -706,6 +707,7 @@ def upsert_client_task(
     Parameters:
         hash (str): Unique identifier for the client task (primary key).
         site (str): Site identifier to store on the record; defaults to "aniworld.to".
+        added_on (Optional[datetime]): Optional timestamp override used for the synthetic torrent's creation/add date.
 
     Returns:
         ClientTask: The persisted ClientTask instance refreshed from the database.
@@ -726,6 +728,7 @@ def upsert_client_task(
             category=category,
             job_id=job_id,
             state=state,
+            added_on=as_aware_utc(added_on) if added_on is not None else utcnow(),
         )
         session.add(rec)
     else:
@@ -740,6 +743,8 @@ def upsert_client_task(
         rec.category = category
         rec.job_id = job_id
         rec.state = state
+        if added_on is not None:
+            rec.added_on = as_aware_utc(added_on)
         session.add(rec)
     try:
         session.commit()

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -703,11 +703,11 @@ def upsert_client_task(
 ) -> ClientTask:
     """
     Create or update a ClientTask record identified by its hash.
-    
+
     Parameters:
         hash (str): Primary key identifying the client task.
         added_on (Optional[datetime]): If provided, used as the task's creation/add date; converted to aware UTC. If omitted on insert, the current UTC time is used. On update, the stored `added_on` is changed only when this argument is provided.
-    
+
     Returns:
         ClientTask: The persisted ClientTask instance refreshed from the database.
     """

--- a/app/providers/sto/v2.py
+++ b/app/providers/sto/v2.py
@@ -92,18 +92,17 @@ def parse_language_id(raw_id: str | None, label: str | None) -> Optional[int]:
 def parse_episode_providers(
     html_text: str, base_url: str
 ) -> Tuple[Dict[str, Dict[int, str]], List[int], List[str]]:
-    """Parse providers and languages from S.to v2 episode HTML.
-
-    Uses BeautifulSoup to locate provider buttons and builds a provider mapping
-    (provider -> language id -> redirect URL), the ordered list of language ids
-    seen, and the corresponding language names.
-
+    """
+    Extract provider redirect URLs and language metadata from an S.to v2 episode HTML page.
+    
     Parameters:
-        html_text: Episode page HTML content.
-        base_url: Base S.to URL for resolving /r?t= redirects.
-
+        html_text (str): Raw HTML of the episode page.
+        base_url (str): Base S.to URL used to resolve relative provider/play URLs.
+    
     Returns:
-        Tuple of (providers, language_ids, language_names).
+        providers (Dict[str, Dict[int, str]]): Mapping from provider name to a mapping of language ID to resolved redirect URL.
+        language_ids (List[int]): Ordered list of language IDs found on the page.
+        language_names (List[str]): List of human-readable language names corresponding to `language_ids`.
     """
     soup = BeautifulSoup(html_text, "html.parser")
     providers: Dict[str, Dict[int, str]] = {}
@@ -137,10 +136,13 @@ def parse_episode_providers(
 
 def parse_release_at_from_sto_html(html_text: str):
     """
-    Parse the published timestamp from S.to v2 episode HTML, if present.
-
+    Extract the UTC release timestamp from S.to v2 episode HTML, if present.
+    
+    Parameters:
+        html_text (str): Raw HTML of the episode page.
+    
     Returns:
-        datetime | None: Parsed UTC timestamp, or None when unavailable.
+        datetime | None: UTC datetime of the episode's release, or None if no timestamp is found.
     """
     return parse_release_at_from_html(html_text)
 
@@ -151,12 +153,23 @@ def enrich_episode_from_v2_html(
     html_text: str,
     base_url: str,
 ) -> None:
-    """Populate an Episode with provider/language data parsed from v2 HTML.
-
+    """
+    Enrich an Episode object with provider, language, and release metadata extracted from S.to v2 HTML.
+    
+    If no providers are found, logs a warning (including the episode link when available) and returns without modifying the episode.
+    
     Parameters:
-        episode: Episode instance to enrich.
-        html_text: Episode page HTML content.
-        base_url: Base S.to URL for resolving redirects.
+        episode (Episode): Episode instance to enrich; this function mutates the object.
+        html_text (str): HTML content of the S.to v2 episode page.
+        base_url (str): Base S.to URL used to resolve provider redirect URLs and other relative links.
+    
+    Side effects:
+        - Sets episode.provider to a mapping of providers to language -> redirect URL.
+        - Sets episode.provider_name to the list of provider names.
+        - Sets episode.language to the ordered list of language IDs when available.
+        - Sets episode.language_name to the list of human-readable language names when available.
+        - If a release timestamp is found, sets episode._anibridge_release_at to that datetime.
+        - Always sets episode._anibridge_sto_v2_html to the raw provided HTML.
     """
     providers, languages, language_names = parse_episode_providers(html_text, base_url)
     if not providers:
@@ -179,14 +192,14 @@ def enrich_episode_from_v2_html(
 
 
 def enrich_episode_from_v2_url(*, episode: "Episode", base_url: str) -> None:
-    """Fetch v2 HTML for the Episode link and populate provider data.
-
-    Uses the shared HTTP client to fetch HTML, then delegates parsing to
-    BeautifulSoup-based helpers.
-
+    """
+    Enriches an Episode with provider, language, and release information by fetching and parsing its S.to v2 page.
+    
+    If the episode has no link, the function returns without modifying the episode. On successful fetch and parse, the function updates the episode's provider-related attributes (e.g., `provider`, `provider_name`, `language`, `language_name`) and may set `_anibridge_release_at` (datetime or None) and `_anibridge_sto_v2_html` (raw HTML string).
+    
     Parameters:
-        episode: Episode instance to enrich (must have a link).
-        base_url: Base S.to URL for resolving redirects.
+        episode (Episode): Episode instance to enrich; must have a `link` attribute to perform fetching.
+        base_url (str): Base S.to URL used to resolve provider redirect URLs.
     """
     link = getattr(episode, "link", None)
     if not link:

--- a/app/providers/sto/v2.py
+++ b/app/providers/sto/v2.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
 from urllib.parse import urljoin
 
@@ -135,19 +134,6 @@ def parse_episode_providers(
     return providers, languages, language_names
 
 
-def parse_release_at_from_sto_html(html_text: str) -> Optional[datetime]:
-    """
-    Extract the UTC release timestamp from S.to v2 episode HTML, if present.
-
-    Parameters:
-        html_text (str): Raw HTML of the episode page.
-
-    Returns:
-        datetime | None: UTC datetime of the episode's release, or None if no timestamp is found.
-    """
-    return parse_release_at_from_html(html_text)
-
-
 def enrich_episode_from_v2_html(
     *,
     episode: "Episode",
@@ -169,7 +155,7 @@ def enrich_episode_from_v2_html(
         - Sets episode.provider_name to the list of provider names.
         - Sets episode.language to the ordered list of language IDs when available.
         - Sets episode.language_name to the list of human-readable language names when available.
-        - If a release timestamp is found, sets episode._anibridge_release_at to that datetime.
+        - Sets episode._anibridge_release_at to the parsed release datetime, or `None` when no timestamp is found.
         - Always sets episode._anibridge_sto_v2_html to the raw provided HTML.
     """
     providers, languages, language_names = parse_episode_providers(html_text, base_url)
@@ -187,9 +173,8 @@ def enrich_episode_from_v2_html(
     if language_names:
         episode.language_name = language_names
 
-    release_at = parse_release_at_from_sto_html(html_text)
-    if release_at is not None:
-        setattr(episode, "_anibridge_release_at", release_at)
+    release_at = parse_release_at_from_html(html_text)
+    setattr(episode, "_anibridge_release_at", release_at)
 
 
 def enrich_episode_from_v2_url(*, episode: "Episode", base_url: str) -> None:

--- a/app/providers/sto/v2.py
+++ b/app/providers/sto/v2.py
@@ -143,7 +143,7 @@ def enrich_episode_from_v2_html(
     """
     Enrich an Episode object with provider, language, and release metadata extracted from S.to v2 HTML.
 
-    If no providers are found, logs a warning (including the episode link when available) and returns without modifying the episode.
+    If no providers are found, logs a warning (including the episode link when available) and returns after storing HTML/release metadata.
 
     Parameters:
         episode (Episode): Episode instance to enrich; this function mutates the object.
@@ -160,6 +160,8 @@ def enrich_episode_from_v2_html(
     """
     providers, languages, language_names = parse_episode_providers(html_text, base_url)
     setattr(episode, "_anibridge_sto_v2_html", html_text)
+    release_at = parse_release_at_from_html(html_text)
+    setattr(episode, "_anibridge_release_at", release_at)
     if not providers:
         logger.warning(
             "No S.to v2 providers parsed for {}", getattr(episode, "link", "<no link>")
@@ -172,10 +174,6 @@ def enrich_episode_from_v2_html(
         episode.language = languages
     if language_names:
         episode.language_name = language_names
-
-    release_at = parse_release_at_from_html(html_text)
-    setattr(episode, "_anibridge_release_at", release_at)
-
 
 def enrich_episode_from_v2_url(*, episode: "Episode", base_url: str) -> None:
     """

--- a/app/providers/sto/v2.py
+++ b/app/providers/sto/v2.py
@@ -8,6 +8,7 @@ from bs4 import BeautifulSoup  # type: ignore
 from loguru import logger
 
 from app.utils.http_client import get as http_get
+from app.utils.release_dates import parse_release_at_from_html
 
 if TYPE_CHECKING:
     from aniworld.models import Episode
@@ -134,6 +135,16 @@ def parse_episode_providers(
     return providers, languages, language_names
 
 
+def parse_release_at_from_sto_html(html_text: str):
+    """
+    Parse the published timestamp from S.to v2 episode HTML, if present.
+
+    Returns:
+        datetime | None: Parsed UTC timestamp, or None when unavailable.
+    """
+    return parse_release_at_from_html(html_text)
+
+
 def enrich_episode_from_v2_html(
     *,
     episode: "Episode",
@@ -160,6 +171,11 @@ def enrich_episode_from_v2_html(
         episode.language = languages
     if language_names:
         episode.language_name = language_names
+
+    release_at = parse_release_at_from_sto_html(html_text)
+    if release_at is not None:
+        setattr(episode, "_anibridge_release_at", release_at)
+    setattr(episode, "_anibridge_sto_v2_html", html_text)
 
 
 def enrich_episode_from_v2_url(*, episode: "Episode", base_url: str) -> None:

--- a/app/providers/sto/v2.py
+++ b/app/providers/sto/v2.py
@@ -173,6 +173,7 @@ def enrich_episode_from_v2_html(
         - Always sets episode._anibridge_sto_v2_html to the raw provided HTML.
     """
     providers, languages, language_names = parse_episode_providers(html_text, base_url)
+    setattr(episode, "_anibridge_sto_v2_html", html_text)
     if not providers:
         logger.warning(
             "No S.to v2 providers parsed for {}", getattr(episode, "link", "<no link>")
@@ -189,7 +190,6 @@ def enrich_episode_from_v2_html(
     release_at = parse_release_at_from_sto_html(html_text)
     if release_at is not None:
         setattr(episode, "_anibridge_release_at", release_at)
-    setattr(episode, "_anibridge_sto_v2_html", html_text)
 
 
 def enrich_episode_from_v2_url(*, episode: "Episode", base_url: str) -> None:

--- a/app/providers/sto/v2.py
+++ b/app/providers/sto/v2.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
 from urllib.parse import urljoin
 
@@ -134,7 +135,7 @@ def parse_episode_providers(
     return providers, languages, language_names
 
 
-def parse_release_at_from_sto_html(html_text: str):
+def parse_release_at_from_sto_html(html_text: str) -> Optional[datetime]:
     """
     Extract the UTC release timestamp from S.to v2 episode HTML, if present.
 

--- a/app/providers/sto/v2.py
+++ b/app/providers/sto/v2.py
@@ -94,11 +94,11 @@ def parse_episode_providers(
 ) -> Tuple[Dict[str, Dict[int, str]], List[int], List[str]]:
     """
     Extract provider redirect URLs and language metadata from an S.to v2 episode HTML page.
-    
+
     Parameters:
         html_text (str): Raw HTML of the episode page.
         base_url (str): Base S.to URL used to resolve relative provider/play URLs.
-    
+
     Returns:
         providers (Dict[str, Dict[int, str]]): Mapping from provider name to a mapping of language ID to resolved redirect URL.
         language_ids (List[int]): Ordered list of language IDs found on the page.
@@ -137,10 +137,10 @@ def parse_episode_providers(
 def parse_release_at_from_sto_html(html_text: str):
     """
     Extract the UTC release timestamp from S.to v2 episode HTML, if present.
-    
+
     Parameters:
         html_text (str): Raw HTML of the episode page.
-    
+
     Returns:
         datetime | None: UTC datetime of the episode's release, or None if no timestamp is found.
     """
@@ -155,14 +155,14 @@ def enrich_episode_from_v2_html(
 ) -> None:
     """
     Enrich an Episode object with provider, language, and release metadata extracted from S.to v2 HTML.
-    
+
     If no providers are found, logs a warning (including the episode link when available) and returns without modifying the episode.
-    
+
     Parameters:
         episode (Episode): Episode instance to enrich; this function mutates the object.
         html_text (str): HTML content of the S.to v2 episode page.
         base_url (str): Base S.to URL used to resolve provider redirect URLs and other relative links.
-    
+
     Side effects:
         - Sets episode.provider to a mapping of providers to language -> redirect URL.
         - Sets episode.provider_name to the list of provider names.
@@ -194,9 +194,9 @@ def enrich_episode_from_v2_html(
 def enrich_episode_from_v2_url(*, episode: "Episode", base_url: str) -> None:
     """
     Enriches an Episode with provider, language, and release information by fetching and parsing its S.to v2 page.
-    
+
     If the episode has no link, the function returns without modifying the episode. On successful fetch and parse, the function updates the episode's provider-related attributes (e.g., `provider`, `provider_name`, `language`, `language_name`) and may set `_anibridge_release_at` (datetime or None) and `_anibridge_sto_v2_html` (raw HTML string).
-    
+
     Parameters:
         episode (Episode): Episode instance to enrich; must have a `link` attribute to perform fetching.
         base_url (str): Base S.to URL used to resolve provider redirect URLs.

--- a/app/providers/sto/v2.py
+++ b/app/providers/sto/v2.py
@@ -175,6 +175,7 @@ def enrich_episode_from_v2_html(
     if language_names:
         episode.language_name = language_names
 
+
 def enrich_episode_from_v2_url(*, episode: "Episode", base_url: str) -> None:
     """
     Enriches an Episode with provider, language, and release information by fetching and parsing its S.to v2 page.

--- a/app/utils/probe_quality.py
+++ b/app/utils/probe_quality.py
@@ -20,12 +20,12 @@ configure_logger()
 def _extract_release_at_from_episode(*, ep: object) -> Optional[datetime]:
     """
     Extracts and caches an episode's release datetime from available HTML content.
-    
+
     This function attempts to retrieve a cached release datetime on the episode object; if absent, it looks for stored HTML (first from the episode's `_anibridge_sto_v2_html`, then from `_html_cache.text`) and parses a release timestamp from that HTML. When a release datetime is found it is cached on the episode as `_anibridge_release_at` for future calls.
-    
+
     Parameters:
         ep (object): Episode-like object that may contain `_anibridge_release_at`, `_anibridge_sto_v2_html`, or `_html_cache.text`.
-    
+
     Returns:
         datetime | None: The parsed release datetime if available, otherwise `None`.
     """
@@ -98,7 +98,7 @@ def probe_episode_quality(
 ) -> tuple[bool, Optional[int], Optional[str], Optional[str], Dict[str, Any] | None]:
     """
     Determine whether an episode is available in the requested language and identify the provider and reported video quality.
-    
+
     Parameters:
         slug (str): Series identifier.
         season (int): Season number.
@@ -107,7 +107,7 @@ def probe_episode_quality(
         preferred_provider (Optional[str]): Provider to try first, if any.
         timeout (float): Socket/metadata probe timeout in seconds.
         site (str): Site identifier used when building the episode object.
-    
+
     Returns:
         tuple:
             available (bool): True if a provider yielded playable metadata for the requested language, False otherwise.

--- a/app/utils/probe_quality.py
+++ b/app/utils/probe_quality.py
@@ -18,6 +18,17 @@ configure_logger()
 
 
 def _extract_release_at_from_episode(*, ep: object) -> Optional[datetime]:
+    """
+    Extracts and caches an episode's release datetime from available HTML content.
+    
+    This function attempts to retrieve a cached release datetime on the episode object; if absent, it looks for stored HTML (first from the episode's `_anibridge_sto_v2_html`, then from `_html_cache.text`) and parses a release timestamp from that HTML. When a release datetime is found it is cached on the episode as `_anibridge_release_at` for future calls.
+    
+    Parameters:
+        ep (object): Episode-like object that may contain `_anibridge_release_at`, `_anibridge_sto_v2_html`, or `_html_cache.text`.
+    
+    Returns:
+        datetime | None: The parsed release datetime if available, otherwise `None`.
+    """
     cached_release = getattr(ep, "_anibridge_release_at", None)
     if cached_release is not None:
         return cached_release
@@ -86,24 +97,24 @@ def probe_episode_quality(
     site: str = "aniworld.to",
 ) -> tuple[bool, Optional[int], Optional[str], Optional[str], Dict[str, Any] | None]:
     """
-    Probe whether an episode is available in the requested language and return the provider used along with reported video quality.
-
+    Determine whether an episode is available in the requested language and identify the provider and reported video quality.
+    
     Parameters:
-        slug (str): Episode identifier (series slug).
+        slug (str): Series identifier.
         season (int): Season number.
         episode (int): Episode number.
         language (str): Desired audio/subtitle language code.
         preferred_provider (Optional[str]): Provider to try first, if any.
         timeout (float): Socket/metadata probe timeout in seconds.
         site (str): Site identifier used when building the episode object.
-
+    
     Returns:
-        tuple[bool, Optional[int], Optional[str], Optional[str], Dict[str, Any] | None]:
-            - available (bool): True if a provider yielded playable metadata for the requested language, False otherwise.
-            - height (Optional[int]): Reported video height in pixels, or None if unavailable.
-            - vcodec (Optional[str]): Reported video codec string, or None if unavailable.
-            - provider_used (Optional[str]): Name of the provider that succeeded, or None if none succeeded.
-            - raw_info (Dict[str, Any] | None): Raw metadata returned by the probe, or None if unavailable.
+        tuple:
+            available (bool): True if a provider yielded playable metadata for the requested language, False otherwise.
+            height (Optional[int]): Reported video height in pixels, or None if unavailable.
+            vcodec (Optional[str]): Reported video codec string, or None if unavailable.
+            provider_used (Optional[str]): Name of the provider that succeeded, or None if none succeeded.
+            raw_info (Dict[str, Any] | None): Raw metadata returned by the probe (may include augmented release timestamp), or None if unavailable.
     """
     logger.info(
         f"Probing episode quality for slug={slug}, season={season}, episode={episode}, language={language}, "

--- a/app/utils/probe_quality.py
+++ b/app/utils/probe_quality.py
@@ -1,15 +1,41 @@
 from __future__ import annotations
+from datetime import datetime
 from typing import Optional, Dict, Any, List, cast
 from loguru import logger
 import yt_dlp
 
 from app.core.downloader import get_direct_url_with_fallback, build_episode
 from app.utils.naming import quality_from_info
+from app.utils.release_dates import (
+    add_release_at_to_probe_info,
+    parse_release_at_from_html,
+)
 from app.config import PROVIDER_ORDER, CATALOG_SITE_CONFIGS
 from app.utils.logger import config as configure_logger
 from app.providers.megakino.client import get_default_client
 
 configure_logger()
+
+
+def _extract_release_at_from_episode(*, ep: object) -> Optional[datetime]:
+    cached_release = getattr(ep, "_anibridge_release_at", None)
+    if cached_release is not None:
+        return cached_release
+
+    html_text = getattr(ep, "_anibridge_sto_v2_html", None)
+    if not isinstance(html_text, str):
+        response = getattr(ep, "_html_cache", None)
+        html_text = getattr(response, "text", None)
+        if not isinstance(html_text, str):
+            html_text = None
+
+    if not html_text:
+        return None
+
+    release_at = parse_release_at_from_html(html_text)
+    if release_at is not None:
+        setattr(ep, "_anibridge_release_at", release_at)
+    return release_at
 
 
 def probe_episode_quality_once(
@@ -126,6 +152,8 @@ def probe_episode_quality(
             )
             logger.debug(f"Got direct URL: {direct} (chosen provider: {chosen})")
             h, vc, info = probe_episode_quality_once(direct, timeout=timeout)
+            release_at = _extract_release_at_from_episode(ep=ep)
+            info = add_release_at_to_probe_info(info, release_at)
             logger.info(
                 f"Provider '{chosen}' succeeded: available=True, height={h}, vcodec={vc}"
             )

--- a/app/utils/release_dates.py
+++ b/app/utils/release_dates.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Any, Optional
+from zoneinfo import ZoneInfo
+
+from bs4 import BeautifulSoup  # type: ignore
+
+RELEASE_AT_EXTRA_KEY = "release_at"
+PROBE_INFO_RELEASE_AT_KEY = "_anibridge_release_at"
+_EUROPE_BERLIN = ZoneInfo("Europe/Berlin")
+
+_MONTH_MAP = {
+    "jan": 1,
+    "januar": 1,
+    "january": 1,
+    "feb": 2,
+    "februar": 2,
+    "february": 2,
+    "mar": 3,
+    "maerz": 3,
+    "märz": 3,
+    "march": 3,
+    "apr": 4,
+    "april": 4,
+    "may": 5,
+    "mai": 5,
+    "jun": 6,
+    "juni": 6,
+    "june": 6,
+    "jul": 7,
+    "juli": 7,
+    "july": 7,
+    "aug": 8,
+    "august": 8,
+    "sep": 9,
+    "sept": 9,
+    "september": 9,
+    "okt": 10,
+    "oct": 10,
+    "oktober": 10,
+    "october": 10,
+    "nov": 11,
+    "november": 11,
+    "dez": 12,
+    "dec": 12,
+    "dezember": 12,
+    "december": 12,
+}
+
+_WEEKDAY_PREFIX_RE = re.compile(
+    r"^\s*(?:"
+    r"montag|dienstag|mittwoch|donnerstag|freitag|samstag|sonntag|"
+    r"monday|tuesday|wednesday|thursday|friday|saturday|sunday"
+    r")\s*,?\s*",
+    re.IGNORECASE,
+)
+_PUBLISH_PREFIX_RE = re.compile(
+    r"\b(?:veröffentlicht(?:\s+bei\s+uns|\s+am)?|published(?:\s+on)?)\b\s*[:\-]?\s*",
+    re.IGNORECASE,
+)
+_GERMAN_DMY_RE = re.compile(
+    r"(?P<day>\d{1,2})\.(?P<month>\d{1,2})\.(?P<year>\d{4})"
+    r"(?:\s+(?P<hour>\d{1,2}):(?P<minute>\d{2}))?",
+    re.IGNORECASE,
+)
+_MONTH_NAME_FIRST_RE = re.compile(
+    r"(?P<month>[A-Za-zÄÖÜäöüß\.]+)\s+"
+    r"(?P<day>\d{1,2}),\s*(?P<year>\d{1,4})"
+    r"(?:\s+(?P<hour>\d{1,2}):(?P<minute>\d{2}))?",
+    re.IGNORECASE,
+)
+_DAY_FIRST_MONTH_NAME_RE = re.compile(
+    r"(?P<day>\d{1,2})\s+"
+    r"(?P<month>[A-Za-zÄÖÜäöüß\.]+)\s+"
+    r"(?P<year>\d{1,4})"
+    r"(?:\s+(?P<hour>\d{1,2}):(?P<minute>\d{2}))?",
+    re.IGNORECASE,
+)
+
+
+def _coerce_month_name(raw: str) -> Optional[int]:
+    key = (raw or "").strip().lower().rstrip(".")
+    return _MONTH_MAP.get(key)
+
+
+def _to_utc(
+    *,
+    year: int,
+    month: int,
+    day: int,
+    hour: int = 0,
+    minute: int = 0,
+) -> Optional[datetime]:
+    if year < 1900:
+        return None
+    try:
+        local_dt = datetime(year, month, day, hour, minute, tzinfo=_EUROPE_BERLIN)
+    except ValueError:
+        return None
+    return local_dt.astimezone(timezone.utc)
+
+
+def parse_release_datetime_text(raw_text: str) -> Optional[datetime]:
+    cleaned = str(raw_text or "").replace("\xa0", " ")
+    cleaned = cleaned.replace("|", " ")
+    cleaned = cleaned.strip()
+    if not cleaned:
+        return None
+
+    cleaned = _PUBLISH_PREFIX_RE.sub("", cleaned)
+    cleaned = _WEEKDAY_PREFIX_RE.sub("", cleaned)
+    cleaned = re.sub(r"\buhr\b", "", cleaned, flags=re.IGNORECASE)
+    cleaned = " ".join(cleaned.split())
+    if not cleaned:
+        return None
+
+    m = _GERMAN_DMY_RE.search(cleaned)
+    if m:
+        return _to_utc(
+            year=int(m.group("year")),
+            month=int(m.group("month")),
+            day=int(m.group("day")),
+            hour=int(m.group("hour") or 0),
+            minute=int(m.group("minute") or 0),
+        )
+
+    m = _MONTH_NAME_FIRST_RE.search(cleaned)
+    if m:
+        month = _coerce_month_name(m.group("month"))
+        if month is None:
+            return None
+        return _to_utc(
+            year=int(m.group("year")),
+            month=month,
+            day=int(m.group("day")),
+            hour=int(m.group("hour") or 0),
+            minute=int(m.group("minute") or 0),
+        )
+
+    m = _DAY_FIRST_MONTH_NAME_RE.search(cleaned)
+    if m:
+        month = _coerce_month_name(m.group("month"))
+        if month is None:
+            return None
+        return _to_utc(
+            year=int(m.group("year")),
+            month=month,
+            day=int(m.group("day")),
+            hour=int(m.group("hour") or 0),
+            minute=int(m.group("minute") or 0),
+        )
+
+    return None
+
+
+def parse_release_at_from_html(html_text: str) -> Optional[datetime]:
+    soup = BeautifulSoup(html_text or "", "html.parser")
+    candidates: list[str] = []
+
+    for text_node in soup.find_all(
+        string=re.compile(r"(veröffentlicht|published)", re.IGNORECASE)
+    ):
+        node = text_node.parent
+        if node is None:
+            continue
+        title_attr = str(node.get("title") or "").strip()
+        if title_attr:
+            candidates.append(title_attr)
+        text = node.get_text(" ", strip=True)
+        if text:
+            candidates.append(text)
+        parent = node.parent
+        if parent is not None:
+            parent_title = str(parent.get("title") or "").strip()
+            if parent_title:
+                candidates.append(parent_title)
+            parent_text = parent.get_text(" ", strip=True)
+            if parent_text:
+                candidates.append(parent_text)
+            for strong in parent.find_all("strong"):
+                strong_text = strong.get_text(" ", strip=True)
+                if strong_text:
+                    candidates.append(strong_text)
+
+    timed_candidates = [c for c in candidates if re.search(r"\d{1,2}:\d{2}", c)]
+    for candidate in timed_candidates + candidates:
+        parsed = parse_release_datetime_text(candidate)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def release_at_from_extra(extra: object) -> Optional[datetime]:
+    if not isinstance(extra, dict):
+        return None
+    return parse_release_datetime_iso(extra.get(RELEASE_AT_EXTRA_KEY))
+
+
+def parse_release_datetime_iso(raw: object) -> Optional[datetime]:
+    if not isinstance(raw, str):
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def release_at_from_probe_info(info: object) -> Optional[datetime]:
+    if not isinstance(info, dict):
+        return None
+    return parse_release_datetime_iso(info.get(PROBE_INFO_RELEASE_AT_KEY))
+
+
+def merge_extra_with_release_at(
+    *,
+    base_extra: Optional[dict[str, Any]],
+    release_at: Optional[datetime],
+) -> Optional[dict[str, Any]]:
+    extra: Optional[dict[str, Any]]
+    if isinstance(base_extra, dict):
+        extra = dict(base_extra)
+    else:
+        extra = None
+
+    if release_at is None:
+        return extra
+
+    if extra is None:
+        extra = {}
+    extra[RELEASE_AT_EXTRA_KEY] = release_at.astimezone(timezone.utc).isoformat()
+    return extra
+
+
+def add_release_at_to_probe_info(
+    info: Optional[dict[str, Any]],
+    release_at: Optional[datetime],
+) -> Optional[dict[str, Any]]:
+    if release_at is None:
+        return info
+
+    payload = dict(info) if isinstance(info, dict) else {}
+    payload[PROBE_INFO_RELEASE_AT_KEY] = release_at.astimezone(timezone.utc).isoformat()
+    return payload

--- a/app/utils/release_dates.py
+++ b/app/utils/release_dates.py
@@ -83,10 +83,10 @@ _DAY_FIRST_MONTH_NAME_RE = re.compile(
 def _coerce_month_name(raw: str) -> Optional[int]:
     """
     Normalize a month-name string and map it to its numeric month value.
-    
+
     Parameters:
         raw (str): Month name or abbreviation (may include punctuation or mixed case).
-    
+
     Returns:
         Optional[int]: Integer month number (1–12) if the input is recognized, otherwise `None`.
     """
@@ -104,9 +104,9 @@ def _to_utc(
 ) -> Optional[datetime]:
     """
     Convert a local Europe/Berlin date and time to a UTC datetime.
-    
+
     Validates that the year is at least 1900 and that the provided date/time components form a valid datetime; returns None for invalid inputs.
-    
+
     Returns:
         A UTC-aware datetime corresponding to the given Berlin-local date and time, or `None` if the inputs are invalid.
     """
@@ -122,14 +122,14 @@ def _to_utc(
 def parse_release_datetime_text(raw_text: str) -> Optional[datetime]:
     """
     Parse a human-readable release date/time string and return it as a UTC datetime.
-    
+
     Accepts strings containing German or English date representations (e.g. D.M.YYYY, "Month day, year", "day Month year")
     with optional time (HH:MM). Common publish prefixes (like "veröffentlicht" / "published"), weekday prefixes, and the
     token "Uhr" are ignored during parsing. If parsing succeeds the resulting datetime is returned normalized to UTC.
-    
+
     Parameters:
         raw_text (str): Input text that may contain a release date/time.
-    
+
     Returns:
         Optional[datetime]: The parsed datetime converted to UTC, or `None` if the text does not contain a parseable date/time.
     """
@@ -188,12 +188,12 @@ def parse_release_datetime_text(raw_text: str) -> Optional[datetime]:
 def parse_release_at_from_html(html_text: str) -> Optional[datetime]:
     """
     Extract a release datetime from HTML containing "veröffentlicht" or "published" annotations.
-    
+
     Parses the provided HTML and examines nearby text and title attributes for candidate strings that indicate a release timestamp, preferring candidates that include an explicit time. If a parseable date/time is found, returns it as a UTC-aware datetime.
-    
+
     Parameters:
         html_text (str): HTML source to scan for release date/time information.
-    
+
     Returns:
         Optional[datetime]: The parsed release datetime in UTC if found, `None` otherwise.
     """
@@ -236,10 +236,10 @@ def parse_release_at_from_html(html_text: str) -> Optional[datetime]:
 def release_at_from_extra(extra: object) -> Optional[datetime]:
     """
     Parse and return the release datetime stored under the "release_at" key in an extra mapping.
-    
+
     Parameters:
         extra (object): Metadata container that may contain a "release_at" ISO datetime string; non-dict inputs are ignored.
-    
+
     Returns:
         Optional[datetime]: The parsed datetime converted to UTC, or None if the key is absent, the input is not a dict, or parsing fails.
     """
@@ -251,10 +251,10 @@ def release_at_from_extra(extra: object) -> Optional[datetime]:
 def parse_release_datetime_iso(raw: object) -> Optional[datetime]:
     """
     Parse an ISO 8601 datetime string into a UTC-aware datetime.
-    
+
     Parameters:
         raw (object): The input expected to be an ISO 8601 datetime string (may end with 'Z' or include an offset). Non-string or empty inputs are treated as invalid.
-    
+
     Returns:
         datetime | None: A timezone-aware `datetime` converted to UTC, or `None` if parsing fails or the input is not a valid ISO 8601 string.
     """
@@ -277,12 +277,12 @@ def parse_release_datetime_iso(raw: object) -> Optional[datetime]:
 def release_at_from_probe_info(info: object) -> Optional[datetime]:
     """
     Extracts the probe-info release timestamp and parses it into a UTC datetime.
-    
+
     Parameters:
-    	info (object): Probe information mapping expected to contain the `_anibridge_release_at` ISO timestamp; if not a dict, the value is treated as absent.
-    
+        info (object): Probe information mapping expected to contain the `_anibridge_release_at` ISO timestamp; if not a dict, the value is treated as absent.
+
     Returns:
-    	`datetime` in UTC if a valid ISO timestamp is present and parsed, `None` otherwise.
+        `datetime` in UTC if a valid ISO timestamp is present and parsed, `None` otherwise.
     """
     if not isinstance(info, dict):
         return None
@@ -296,11 +296,11 @@ def merge_extra_with_release_at(
 ) -> Optional[dict[str, Any]]:
     """
     Return a shallow copy of `base_extra` augmented with a UTC ISO 8601 `release_at` timestamp when provided.
-    
+
     Parameters:
         base_extra (Optional[dict[str, Any]]): The original extra dictionary to copy and augment. If not a dict, it is treated as absent.
         release_at (Optional[datetime]): The datetime to store under the `release_at` key; converted to UTC and formatted as an ISO 8601 string.
-    
+
     Returns:
         Optional[dict[str, Any]]: If `release_at` is provided, a dict (a shallow copy of `base_extra` if it was a dict, otherwise a new dict) containing the `release_at` ISO string. If `release_at` is None, returns a shallow copy of `base_extra` when it is a dict, or `None` if `base_extra` was not a dict.
     """
@@ -325,13 +325,13 @@ def add_release_at_to_probe_info(
 ) -> Optional[dict[str, Any]]:
     """
     Return a probe-info dictionary augmented with a release timestamp under the key "_anibridge_release_at".
-    
+
     If `release_at` is None, the original `info` value is returned unchanged. If `info` is a dict it is shallow-copied before modification; if `info` is not a dict a new dict is created. The `release_at` value is converted to UTC and stored as an ISO 8601 string.
-    
+
     Parameters:
         info (Optional[dict[str, Any]]): Existing probe-info mapping, or None.
         release_at (Optional[datetime]): Release datetime to add.
-    
+
     Returns:
         Optional[dict[str, Any]]: The probe-info dict containing the `_anibridge_release_at` ISO 8601 UTC string, or the original `info` if `release_at` is None.
     """

--- a/app/utils/release_dates.py
+++ b/app/utils/release_dates.py
@@ -81,6 +81,15 @@ _DAY_FIRST_MONTH_NAME_RE = re.compile(
 
 
 def _coerce_month_name(raw: str) -> Optional[int]:
+    """
+    Normalize a month-name string and map it to its numeric month value.
+    
+    Parameters:
+        raw (str): Month name or abbreviation (may include punctuation or mixed case).
+    
+    Returns:
+        Optional[int]: Integer month number (1–12) if the input is recognized, otherwise `None`.
+    """
     key = (raw or "").strip().lower().rstrip(".")
     return _MONTH_MAP.get(key)
 
@@ -93,6 +102,14 @@ def _to_utc(
     hour: int = 0,
     minute: int = 0,
 ) -> Optional[datetime]:
+    """
+    Convert a local Europe/Berlin date and time to a UTC datetime.
+    
+    Validates that the year is at least 1900 and that the provided date/time components form a valid datetime; returns None for invalid inputs.
+    
+    Returns:
+        A UTC-aware datetime corresponding to the given Berlin-local date and time, or `None` if the inputs are invalid.
+    """
     if year < 1900:
         return None
     try:
@@ -103,6 +120,19 @@ def _to_utc(
 
 
 def parse_release_datetime_text(raw_text: str) -> Optional[datetime]:
+    """
+    Parse a human-readable release date/time string and return it as a UTC datetime.
+    
+    Accepts strings containing German or English date representations (e.g. D.M.YYYY, "Month day, year", "day Month year")
+    with optional time (HH:MM). Common publish prefixes (like "veröffentlicht" / "published"), weekday prefixes, and the
+    token "Uhr" are ignored during parsing. If parsing succeeds the resulting datetime is returned normalized to UTC.
+    
+    Parameters:
+        raw_text (str): Input text that may contain a release date/time.
+    
+    Returns:
+        Optional[datetime]: The parsed datetime converted to UTC, or `None` if the text does not contain a parseable date/time.
+    """
     cleaned = str(raw_text or "").replace("\xa0", " ")
     cleaned = cleaned.replace("|", " ")
     cleaned = cleaned.strip()
@@ -156,6 +186,17 @@ def parse_release_datetime_text(raw_text: str) -> Optional[datetime]:
 
 
 def parse_release_at_from_html(html_text: str) -> Optional[datetime]:
+    """
+    Extract a release datetime from HTML containing "veröffentlicht" or "published" annotations.
+    
+    Parses the provided HTML and examines nearby text and title attributes for candidate strings that indicate a release timestamp, preferring candidates that include an explicit time. If a parseable date/time is found, returns it as a UTC-aware datetime.
+    
+    Parameters:
+        html_text (str): HTML source to scan for release date/time information.
+    
+    Returns:
+        Optional[datetime]: The parsed release datetime in UTC if found, `None` otherwise.
+    """
     soup = BeautifulSoup(html_text or "", "html.parser")
     candidates: list[str] = []
 
@@ -193,12 +234,30 @@ def parse_release_at_from_html(html_text: str) -> Optional[datetime]:
 
 
 def release_at_from_extra(extra: object) -> Optional[datetime]:
+    """
+    Parse and return the release datetime stored under the "release_at" key in an extra mapping.
+    
+    Parameters:
+        extra (object): Metadata container that may contain a "release_at" ISO datetime string; non-dict inputs are ignored.
+    
+    Returns:
+        Optional[datetime]: The parsed datetime converted to UTC, or None if the key is absent, the input is not a dict, or parsing fails.
+    """
     if not isinstance(extra, dict):
         return None
     return parse_release_datetime_iso(extra.get(RELEASE_AT_EXTRA_KEY))
 
 
 def parse_release_datetime_iso(raw: object) -> Optional[datetime]:
+    """
+    Parse an ISO 8601 datetime string into a UTC-aware datetime.
+    
+    Parameters:
+        raw (object): The input expected to be an ISO 8601 datetime string (may end with 'Z' or include an offset). Non-string or empty inputs are treated as invalid.
+    
+    Returns:
+        datetime | None: A timezone-aware `datetime` converted to UTC, or `None` if parsing fails or the input is not a valid ISO 8601 string.
+    """
     if not isinstance(raw, str):
         return None
     text = raw.strip()
@@ -216,6 +275,15 @@ def parse_release_datetime_iso(raw: object) -> Optional[datetime]:
 
 
 def release_at_from_probe_info(info: object) -> Optional[datetime]:
+    """
+    Extracts the probe-info release timestamp and parses it into a UTC datetime.
+    
+    Parameters:
+    	info (object): Probe information mapping expected to contain the `_anibridge_release_at` ISO timestamp; if not a dict, the value is treated as absent.
+    
+    Returns:
+    	`datetime` in UTC if a valid ISO timestamp is present and parsed, `None` otherwise.
+    """
     if not isinstance(info, dict):
         return None
     return parse_release_datetime_iso(info.get(PROBE_INFO_RELEASE_AT_KEY))
@@ -226,6 +294,16 @@ def merge_extra_with_release_at(
     base_extra: Optional[dict[str, Any]],
     release_at: Optional[datetime],
 ) -> Optional[dict[str, Any]]:
+    """
+    Return a shallow copy of `base_extra` augmented with a UTC ISO 8601 `release_at` timestamp when provided.
+    
+    Parameters:
+        base_extra (Optional[dict[str, Any]]): The original extra dictionary to copy and augment. If not a dict, it is treated as absent.
+        release_at (Optional[datetime]): The datetime to store under the `release_at` key; converted to UTC and formatted as an ISO 8601 string.
+    
+    Returns:
+        Optional[dict[str, Any]]: If `release_at` is provided, a dict (a shallow copy of `base_extra` if it was a dict, otherwise a new dict) containing the `release_at` ISO string. If `release_at` is None, returns a shallow copy of `base_extra` when it is a dict, or `None` if `base_extra` was not a dict.
+    """
     extra: Optional[dict[str, Any]]
     if isinstance(base_extra, dict):
         extra = dict(base_extra)
@@ -245,6 +323,18 @@ def add_release_at_to_probe_info(
     info: Optional[dict[str, Any]],
     release_at: Optional[datetime],
 ) -> Optional[dict[str, Any]]:
+    """
+    Return a probe-info dictionary augmented with a release timestamp under the key "_anibridge_release_at".
+    
+    If `release_at` is None, the original `info` value is returned unchanged. If `info` is a dict it is shallow-copied before modification; if `info` is not a dict a new dict is created. The `release_at` value is converted to UTC and stored as an ISO 8601 string.
+    
+    Parameters:
+        info (Optional[dict[str, Any]]): Existing probe-info mapping, or None.
+        release_at (Optional[datetime]): Release datetime to add.
+    
+    Returns:
+        Optional[dict[str, Any]]: The probe-info dict containing the `_anibridge_release_at` ISO 8601 UTC string, or the original `info` if `release_at` is None.
+    """
     if release_at is None:
         return info
 

--- a/app/utils/release_dates.py
+++ b/app/utils/release_dates.py
@@ -1,8 +1,24 @@
+"""Release date parsing and reconciliation utilities.
+
+This module parses release date strings from text and HTML, normalizes them
+to UTC, and reconciles release timestamps across extra metadata and probe
+payloads. `BeautifulSoup` is used to parse provider HTML snippets where release
+information is embedded in text nodes and element attributes.
+
+Constants:
+    RELEASE_AT_EXTRA_KEY: Canonical key used to store release timestamps in
+        availability `extra` dictionaries.
+    PROBE_INFO_RELEASE_AT_KEY: Canonical key used to store release timestamps
+        in probe info payloads.
+    _EUROPE_BERLIN: Local timezone used when interpreting site date strings
+        that are published in Berlin local time.
+"""
+
 from __future__ import annotations
 
 import re
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional
 from zoneinfo import ZoneInfo
 
 from bs4 import BeautifulSoup  # type: ignore
@@ -57,7 +73,8 @@ _WEEKDAY_PREFIX_RE = re.compile(
     re.IGNORECASE,
 )
 _PUBLISH_PREFIX_RE = re.compile(
-    r"\b(?:veröffentlicht(?:\s+bei\s+uns|\s+am)?|published(?:\s+on)?)\b\s*[:\-]?\s*",
+    r"\b(?:veröffentlicht(?:\s+bei\s+uns|\s+am)?|"
+    r"published(?:\s+on)?)\b\s*[:\-]?\s*",
     re.IGNORECASE,
 )
 _GERMAN_DMY_RE = re.compile(
@@ -198,7 +215,7 @@ def parse_release_at_from_html(html_text: str) -> Optional[datetime]:
         Optional[datetime]: The parsed release datetime in UTC if found, `None` otherwise.
     """
     soup = BeautifulSoup(html_text or "", "html.parser")
-    candidates: list[str] = []
+    candidates: List[str] = []
 
     for text_node in soup.find_all(
         string=re.compile(r"(veröffentlicht|published)", re.IGNORECASE)
@@ -291,20 +308,20 @@ def release_at_from_probe_info(info: object) -> Optional[datetime]:
 
 def merge_extra_with_release_at(
     *,
-    base_extra: Optional[dict[str, Any]],
+    base_extra: Optional[Dict[str, Any]],
     release_at: Optional[datetime],
-) -> Optional[dict[str, Any]]:
+) -> Optional[Dict[str, Any]]:
     """
     Return a shallow copy of `base_extra` augmented with a UTC ISO 8601 `release_at` timestamp when provided.
 
     Parameters:
-        base_extra (Optional[dict[str, Any]]): The original extra dictionary to copy and augment. If not a dict, it is treated as absent.
+        base_extra (Optional[Dict[str, Any]]): The original extra dictionary to copy and augment. If not a dict, it is treated as absent.
         release_at (Optional[datetime]): The datetime to store under the `release_at` key; converted to UTC and formatted as an ISO 8601 string.
 
     Returns:
-        Optional[dict[str, Any]]: If `release_at` is provided, a dict (a shallow copy of `base_extra` if it was a dict, otherwise a new dict) containing the `release_at` ISO string. If `release_at` is None, returns a shallow copy of `base_extra` when it is a dict, or `None` if `base_extra` was not a dict.
+        Optional[Dict[str, Any]]: If `release_at` is provided, a dict (a shallow copy of `base_extra` if it was a dict, otherwise a new dict) containing the `release_at` ISO string. If `release_at` is None, returns a shallow copy of `base_extra` when it is a dict, or `None` if `base_extra` was not a dict.
     """
-    extra: Optional[dict[str, Any]]
+    extra: Optional[Dict[str, Any]]
     if isinstance(base_extra, dict):
         extra = dict(base_extra)
     else:
@@ -320,20 +337,20 @@ def merge_extra_with_release_at(
 
 
 def add_release_at_to_probe_info(
-    info: Optional[dict[str, Any]],
+    info: Optional[Dict[str, Any]],
     release_at: Optional[datetime],
-) -> Optional[dict[str, Any]]:
+) -> Optional[Dict[str, Any]]:
     """
     Return a probe-info dictionary augmented with a release timestamp under the key "_anibridge_release_at".
 
     If `release_at` is None, the original `info` value is returned unchanged. If `info` is a dict it is shallow-copied before modification; if `info` is not a dict a new dict is created. The `release_at` value is converted to UTC and stored as an ISO 8601 string.
 
     Parameters:
-        info (Optional[dict[str, Any]]): Existing probe-info mapping, or None.
+        info (Optional[Dict[str, Any]]): Existing probe-info mapping, or None.
         release_at (Optional[datetime]): Release datetime to add.
 
     Returns:
-        Optional[dict[str, Any]]: The probe-info dict containing the `_anibridge_release_at` ISO 8601 UTC string, or the original `info` if `release_at` is None.
+        Optional[Dict[str, Any]]: The probe-info dict containing the `_anibridge_release_at` ISO 8601 UTC string, or the original `info` if `release_at` is None.
     """
     if release_at is None:
         return info

--- a/docker/docker-compose.dev.vpn.yaml
+++ b/docker/docker-compose.dev.vpn.yaml
@@ -15,7 +15,8 @@ services:
       - ../data/downloads:/downloads
     network_mode: 'service:vpn'
     depends_on:
-      - vpn
+      vpn:
+        condition: service_healthy
     healthcheck:
       test:
         [

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,6 +16,7 @@ def test_job_crud_and_cleanup(client):
 
 
 def test_availability_and_clienttask_crud(client):
+    from datetime import datetime, timezone
     from sqlmodel import Session
     from app.db import (
         engine,
@@ -136,7 +137,12 @@ def test_availability_and_clienttask_crud(client):
             category="anime",
             job_id="job-1",
             state="downloading",
+            added_on=datetime(2026, 2, 23, 19, 47, tzinfo=timezone.utc),
         )
-        assert get_client_task(s, "abc")
+        task = get_client_task(s, "abc")
+        assert task
+        assert task.added_on.replace(tzinfo=timezone.utc) == datetime(
+            2026, 2, 23, 19, 47, tzinfo=timezone.utc
+        )
         delete_client_task(s, "abc")
         assert get_client_task(s, "abc") is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -30,6 +30,7 @@ def test_availability_and_clienttask_crud(client):
         upsert_client_task,
         get_client_task,
         delete_client_task,
+        as_aware_utc,
     )
 
     with Session(engine) as s:
@@ -141,7 +142,7 @@ def test_availability_and_clienttask_crud(client):
         )
         task = get_client_task(s, "abc")
         assert task
-        assert task.added_on.replace(tzinfo=timezone.utc) == datetime(
+        assert as_aware_utc(task.added_on) == datetime(
             2026, 2, 23, 19, 47, tzinfo=timezone.utc
         )
         delete_client_task(s, "abc")

--- a/tests/test_qbittorrent_torrents.py
+++ b/tests/test_qbittorrent_torrents.py
@@ -76,7 +76,7 @@ def test_torrents_add_aw_and_sto_prefixes(client):
 def test_torrents_add_uses_cached_release_timestamp_for_added_on(client):
     """
     Verify that adding a torrent uses a cached release timestamp for the torrent's added_on field.
-    
+
     Sets an availability record with a release_at timestamp, adds a torrent for that release, and asserts the torrent's `added_on` equals the integer Unix timestamp of the cached `release_at`.
     """
     from datetime import datetime, timezone

--- a/tests/test_qbittorrent_torrents.py
+++ b/tests/test_qbittorrent_torrents.py
@@ -71,3 +71,44 @@ def test_torrents_add_aw_and_sto_prefixes(client):
     info = client.get("/api/v2/torrents/info")
     items = info.json()
     assert len(items) == 2
+
+
+def test_torrents_add_uses_cached_release_timestamp_for_added_on(client):
+    from datetime import datetime, timezone
+    from sqlmodel import Session
+
+    from app.db import engine, upsert_availability
+    from app.utils.magnet import build_magnet
+
+    release_at = datetime(2026, 2, 23, 19, 47, tzinfo=timezone.utc)
+    with Session(engine) as s:
+        upsert_availability(
+            s,
+            slug="release-slug",
+            season=1,
+            episode=1,
+            language="German Dub",
+            available=True,
+            height=1080,
+            vcodec="h264",
+            provider="VOE",
+            extra={"release_at": release_at.isoformat()},
+            site="aniworld.to",
+        )
+
+    magnet = build_magnet(
+        title="Title Release",
+        slug="release-slug",
+        season=1,
+        episode=1,
+        language="German Dub",
+    )
+    add = client.post(
+        "/api/v2/torrents/add", data={"urls": magnet, "category": "anime"}
+    )
+    assert add.status_code == 200
+
+    info = client.get("/api/v2/torrents/info")
+    items = info.json()
+    assert len(items) == 1
+    assert items[0]["added_on"] == int(release_at.timestamp())

--- a/tests/test_qbittorrent_torrents.py
+++ b/tests/test_qbittorrent_torrents.py
@@ -74,6 +74,11 @@ def test_torrents_add_aw_and_sto_prefixes(client):
 
 
 def test_torrents_add_uses_cached_release_timestamp_for_added_on(client):
+    """
+    Verify that adding a torrent uses a cached release timestamp for the torrent's added_on field.
+    
+    Sets an availability record with a release_at timestamp, adds a torrent for that release, and asserts the torrent's `added_on` equals the integer Unix timestamp of the cached `release_at`.
+    """
     from datetime import datetime, timezone
     from sqlmodel import Session
 

--- a/tests/test_qbittorrent_torrents.py
+++ b/tests/test_qbittorrent_torrents.py
@@ -73,7 +73,7 @@ def test_torrents_add_aw_and_sto_prefixes(client):
     assert len(items) == 2
 
 
-def test_torrents_add_uses_cached_release_timestamp_for_added_on(client):
+def test_torrents_add_uses_cached_release_timestamp_for_added_on(client) -> None:
     """
     Verify that adding a torrent uses a cached release timestamp for the torrent's added_on field.
 
@@ -84,6 +84,7 @@ def test_torrents_add_uses_cached_release_timestamp_for_added_on(client):
 
     from app.db import engine, upsert_availability
     from app.utils.magnet import build_magnet
+    from app.utils.release_dates import RELEASE_AT_EXTRA_KEY
 
     release_at = datetime(2026, 2, 23, 19, 47, tzinfo=timezone.utc)
     with Session(engine) as s:
@@ -97,7 +98,7 @@ def test_torrents_add_uses_cached_release_timestamp_for_added_on(client):
             height=1080,
             vcodec="h264",
             provider="VOE",
-            extra={"release_at": release_at.isoformat()},
+            extra={RELEASE_AT_EXTRA_KEY: release_at.isoformat()},
             site="aniworld.to",
         )
 

--- a/tests/test_release_dates.py
+++ b/tests/test_release_dates.py
@@ -11,12 +11,14 @@ from app.utils.release_dates import (
 
 
 def test_parse_release_datetime_text_german_with_time() -> None:
+    """Parse German release strings with time to UTC."""
     parsed = parse_release_datetime_text("Freitag, 29.08.2025 18:46 Uhr")
 
     assert parsed == datetime(2025, 8, 29, 16, 46, tzinfo=timezone.utc)
 
 
 def test_parse_release_at_from_html_sto_v2_like_markup() -> None:
+    """Parse release datetime from STO v2-like HTML markup."""
     html_text = """
     <span class="flex-grow-1">
       <span title="Feb 23, 2026 20:47 Uhr">
@@ -31,6 +33,7 @@ def test_parse_release_at_from_html_sto_v2_like_markup() -> None:
 
 
 def test_parse_release_at_from_html_ignores_invalid_year() -> None:
+    """Return None for HTML with an invalid year."""
     html_text = """
     <span title="Nov 30, -0001 00:00">
       Published on November 30, -0001
@@ -41,6 +44,7 @@ def test_parse_release_at_from_html_ignores_invalid_year() -> None:
 
 
 def test_release_at_roundtrip_via_extra_and_probe_info() -> None:
+    """Roundtrip release_at through extra and probe info helpers."""
     release_at = datetime(2026, 2, 23, 19, 47, tzinfo=timezone.utc)
     extra = merge_extra_with_release_at(base_extra={"x": 1}, release_at=release_at)
     info = add_release_at_to_probe_info({}, release_at)

--- a/tests/test_release_dates.py
+++ b/tests/test_release_dates.py
@@ -1,0 +1,50 @@
+from datetime import datetime, timezone
+
+from app.utils.release_dates import (
+    add_release_at_to_probe_info,
+    merge_extra_with_release_at,
+    parse_release_at_from_html,
+    parse_release_datetime_text,
+    release_at_from_extra,
+    release_at_from_probe_info,
+)
+
+
+def test_parse_release_datetime_text_german_with_time() -> None:
+    parsed = parse_release_datetime_text("Freitag, 29.08.2025 18:46 Uhr")
+
+    assert parsed == datetime(2025, 8, 29, 16, 46, tzinfo=timezone.utc)
+
+
+def test_parse_release_at_from_html_sto_v2_like_markup() -> None:
+    html_text = """
+    <span class="flex-grow-1">
+      <span title="Feb 23, 2026 20:47 Uhr">
+        Veröffentlicht am February 23, 2026
+      </span>
+    </span>
+    """
+
+    parsed = parse_release_at_from_html(html_text)
+
+    assert parsed == datetime(2026, 2, 23, 19, 47, tzinfo=timezone.utc)
+
+
+def test_parse_release_at_from_html_ignores_invalid_year() -> None:
+    html_text = """
+    <span title="Nov 30, -0001 00:00">
+      Published on November 30, -0001
+    </span>
+    """
+
+    assert parse_release_at_from_html(html_text) is None
+
+
+def test_release_at_roundtrip_via_extra_and_probe_info() -> None:
+    release_at = datetime(2026, 2, 23, 19, 47, tzinfo=timezone.utc)
+    extra = merge_extra_with_release_at(base_extra={"x": 1}, release_at=release_at)
+    info = add_release_at_to_probe_info({}, release_at)
+
+    assert extra is not None
+    assert release_at_from_extra(extra) == release_at
+    assert release_at_from_probe_info(info) == release_at

--- a/tests/test_sto_v2.py
+++ b/tests/test_sto_v2.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from app.providers.sto.v2 import (
     build_episode_url,
     parse_episode_providers,
+    parse_release_at_from_sto_html,
     parse_language_id,
 )
 
@@ -57,3 +58,18 @@ def test_parse_episode_providers_from_fixture() -> None:
     assert 2 in languages
     assert "German Dub" in language_names
     assert "English Dub" in language_names
+
+
+def test_parse_release_at_from_sto_html_prefers_title_timestamp() -> None:
+    html_text = """
+    <span class="flex-grow-1">
+      <span title="Feb 23, 2026 20:47 Uhr">
+        Veröffentlicht am February 23, 2026
+      </span>
+    </span>
+    """
+
+    parsed = parse_release_at_from_sto_html(html_text)
+
+    assert parsed is not None
+    assert parsed.isoformat() == "2026-02-23T19:47:00+00:00"

--- a/tests/test_sto_v2.py
+++ b/tests/test_sto_v2.py
@@ -61,6 +61,11 @@ def test_parse_episode_providers_from_fixture() -> None:
 
 
 def test_parse_release_at_from_sto_html_prefers_title_timestamp() -> None:
+    """Prefer title timestamp when both title and visible text are present.
+
+    Ensures parse_release_at_from_sto_html resolves the title value and returns
+    the expected ISO 8601 UTC datetime.
+    """
     html_text = """
     <span class="flex-grow-1">
       <span title="Feb 23, 2026 20:47 Uhr">

--- a/tests/test_sto_v2.py
+++ b/tests/test_sto_v2.py
@@ -3,9 +3,9 @@ from pathlib import Path
 from app.providers.sto.v2 import (
     build_episode_url,
     parse_episode_providers,
-    parse_release_at_from_sto_html,
     parse_language_id,
 )
+from app.utils.release_dates import parse_release_at_from_html
 
 
 def _read_episode_fixture() -> str:
@@ -63,7 +63,7 @@ def test_parse_episode_providers_from_fixture() -> None:
 def test_parse_release_at_from_sto_html_prefers_title_timestamp() -> None:
     """Prefer title timestamp when both title and visible text are present.
 
-    Ensures parse_release_at_from_sto_html resolves the title value and returns
+    Ensures parse_release_at_from_html resolves the title value and returns
     the expected ISO 8601 UTC datetime.
     """
     html_text = """
@@ -74,7 +74,7 @@ def test_parse_release_at_from_sto_html_prefers_title_timestamp() -> None:
     </span>
     """
 
-    parsed = parse_release_at_from_sto_html(html_text)
+    parsed = parse_release_at_from_html(html_text)
 
     assert parsed is not None
     assert parsed.isoformat() == "2026-02-23T19:47:00+00:00"

--- a/tests/test_torznab.py
+++ b/tests/test_torznab.py
@@ -1,4 +1,5 @@
 import xml.etree.ElementTree as ET
+from typing import Any
 
 
 def test_caps(client):
@@ -75,7 +76,13 @@ def test_tvsearch_happy_path(client, monkeypatch):
     assert subs_attr is not None and subs_attr.get("value") == "German"
 
 
-def test_tvsearch_uses_cached_release_timestamp_for_pubdate(client, monkeypatch):
+def test_tvsearch_uses_cached_release_timestamp_for_pubdate(
+    client: Any, monkeypatch: Any
+) -> None:
+    """Use cached release timestamp as pubDate when availability metadata has it.
+
+    This verifies tvsearch emits `pubDate` from cached `extra` release metadata.
+    """
     import app.api.torznab as tn
 
     class Rec:
@@ -84,7 +91,7 @@ def test_tvsearch_uses_cached_release_timestamp_for_pubdate(client, monkeypatch)
         height = 1080
         vcodec = "h264"
         provider = "prov"
-        extra = {"release_at": "2026-02-23T19:47:00+00:00"}
+        extra = {tn.RELEASE_AT_EXTRA_KEY: "2026-02-23T19:47:00+00:00"}
 
     monkeypatch.setattr(
         tn, "_slug_from_query", lambda q, site=None: ("aniworld.to", "slug")

--- a/tests/test_torznab.py
+++ b/tests/test_torznab.py
@@ -75,6 +75,61 @@ def test_tvsearch_happy_path(client, monkeypatch):
     assert subs_attr is not None and subs_attr.get("value") == "German"
 
 
+def test_tvsearch_uses_cached_release_timestamp_for_pubdate(client, monkeypatch):
+    import app.api.torznab as tn
+
+    class Rec:
+        available = True
+        is_fresh = True
+        height = 1080
+        vcodec = "h264"
+        provider = "prov"
+        extra = {"release_at": "2026-02-23T19:47:00+00:00"}
+
+    monkeypatch.setattr(
+        tn, "_slug_from_query", lambda q, site=None: ("aniworld.to", "slug")
+    )
+    monkeypatch.setattr(
+        tn, "resolve_series_title", lambda slug, site="aniworld.to": "Series"
+    )
+    monkeypatch.setattr(
+        tn,
+        "list_available_languages_cached",
+        lambda session, slug, season, episode, site="aniworld.to": ["German Sub"],
+    )
+    monkeypatch.setattr(
+        tn,
+        "get_availability",
+        lambda session, slug, season, episode, language, site="aniworld.to": Rec(),
+    )
+    monkeypatch.setattr(
+        tn,
+        "build_release_name",
+        lambda series_title, season, episode, height, vcodec, language, site="aniworld.to": (
+            "Title"
+        ),
+    )
+    monkeypatch.setattr(
+        tn,
+        "build_magnet",
+        lambda title, slug, season, episode, language, provider, site="aniworld.to", **_kwargs: (
+            "magnet:?xt=urn:btih:test&dn=Title&aw_slug=slug&aw_s=1&aw_e=1&aw_lang=German+Sub&aw_site=aniworld.to"
+        ),
+    )
+
+    resp = client.get(
+        "/torznab/api",
+        params={"t": "tvsearch", "q": "foo", "season": 1, "ep": 1},
+    )
+    assert resp.status_code == 200
+    root = ET.fromstring(resp.text)
+    item = root.find("./channel/item")
+    assert item is not None
+    pub_date = item.find("pubDate")
+    assert pub_date is not None
+    assert pub_date.text == "Mon, 23 Feb 2026 19:47:00 +0000"
+
+
 def test_tvsearch_empty(client):
     resp = client.get("/torznab/api", params={"t": "tvsearch", "q": "foo"})
     assert resp.status_code == 200


### PR DESCRIPTION
## Description

This pull request introduces release-aware timestamps throughout the system, ensuring that episode and torrent timestamps (such as `pubDate` and `added_on`) reflect the actual provider publish time when available, rather than the time of the request. This improves the accuracy and reliability of metadata for both users and downstream consumers (like Sonarr/Prowlarr). The changes also refactor and centralize logic for handling release dates, and propagate this information through the API and database layers. Closes #7.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Testing

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

## Additional Notes

**Release-aware timestamp handling:**

* Added logic to extract and propagate release timestamps from provider metadata, using the actual publish time where available instead of the request time. This affects `AniWorld`, `s.to`, and related endpoints, and is now reflected in the README documentation. [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R17) [[2]](diffhunk://#diff-8e5009db39ac98f29459255e967d3a2d67a5be1a4e6742329eed5d00ee218f77R121-R142) [[3]](diffhunk://#diff-8e5009db39ac98f29459255e967d3a2d67a5be1a4e6742329eed5d00ee218f77R157)
* Introduced utility functions (`_to_utc_timestamp`, `release_at_from_extra`, etc.) to standardize conversion and retrieval of UTC timestamps across the codebase. [[1]](diffhunk://#diff-c481ea4607c3905f6388f2fe3c84b67c9e705c47d59fb339208ba37555b23091R16-R23) [[2]](diffhunk://#diff-8e5009db39ac98f29459255e967d3a2d67a5be1a4e6742329eed5d00ee218f77R23-R39) [[3]](diffhunk://#diff-8e5009db39ac98f29459255e967d3a2d67a5be1a4e6742329eed5d00ee218f77R3) [[4]](diffhunk://#diff-2621c2002e7f645f0bc933a944feefd8b0bf92e121e43715b14107dc9b6117d5R41-R46)

**API and data model updates:**

* Updated `/qbittorrent/sync` and `/qbittorrent/torrents` endpoints to store and return release-aware timestamps for `added_on` and `completion_on` fields, ensuring clients receive accurate publish dates. [[1]](diffhunk://#diff-c481ea4607c3905f6388f2fe3c84b67c9e705c47d59fb339208ba37555b23091L53-R62) [[2]](diffhunk://#diff-c481ea4607c3905f6388f2fe3c84b67c9e705c47d59fb339208ba37555b23091L67-R76) [[3]](diffhunk://#diff-c481ea4607c3905f6388f2fe3c84b67c9e705c47d59fb339208ba37555b23091L82-R91) [[4]](diffhunk://#diff-8e5009db39ac98f29459255e967d3a2d67a5be1a4e6742329eed5d00ee218f77L209-R244) [[5]](diffhunk://#diff-8e5009db39ac98f29459255e967d3a2d67a5be1a4e6742329eed5d00ee218f77L290-R325)
* Refactored Torznab API endpoints to emit correct `pubDate` values in RSS feeds, using release-aware timestamps when available, and to store this information in the availability cache. [[1]](diffhunk://#diff-2621c2002e7f645f0bc933a944feefd8b0bf92e121e43715b14107dc9b6117d5R860-R871) [[2]](diffhunk://#diff-2621c2002e7f645f0bc933a944feefd8b0bf92e121e43715b14107dc9b6117d5R893-R896) [[3]](diffhunk://#diff-2621c2002e7f645f0bc933a944feefd8b0bf92e121e43715b14107dc9b6117d5L840-R906) [[4]](diffhunk://#diff-2621c2002e7f645f0bc933a944feefd8b0bf92e121e43715b14107dc9b6117d5R926-R932) [[5]](diffhunk://#diff-2621c2002e7f645f0bc933a944feefd8b0bf92e121e43715b14107dc9b6117d5R971) [[6]](diffhunk://#diff-2621c2002e7f645f0bc933a944feefd8b0bf92e121e43715b14107dc9b6117d5R980-R984) [[7]](diffhunk://#diff-2621c2002e7f645f0bc933a944feefd8b0bf92e121e43715b14107dc9b6117d5L918-R1008) [[8]](diffhunk://#diff-2621c2002e7f645f0bc933a944feefd8b0bf92e121e43715b14107dc9b6117d5L1013-R1096)

**Internal logic and utilities:**

* Centralized and improved merging of extra metadata with release timestamps for both direct and mapped (special) episode probes, ensuring consistency and reducing code duplication. [[1]](diffhunk://#diff-2621c2002e7f645f0bc933a944feefd8b0bf92e121e43715b14107dc9b6117d5R121-R151) [[2]](diffhunk://#diff-2621c2002e7f645f0bc933a944feefd8b0bf92e121e43715b14107dc9b6117d5L471-R508) [[3]](diffhunk://#diff-2621c2002e7f645f0bc933a944feefd8b0bf92e121e43715b14107dc9b6117d5R522) [[4]](diffhunk://#diff-2621c2002e7f645f0bc933a944feefd8b0bf92e121e43715b14107dc9b6117d5L497-R539) [[5]](diffhunk://#diff-2621c2002e7f645f0bc933a944feefd8b0bf92e121e43715b14107dc9b6117d5L618-R670) [[6]](diffhunk://#diff-2621c2002e7f645f0bc933a944feefd8b0bf92e121e43715b14107dc9b6117d5L639-R692) [[7]](diffhunk://#diff-2621c2002e7f645f0bc933a944feefd8b0bf92e121e43715b14107dc9b6117d5R721-R725) [[8]](diffhunk://#diff-2621c2002e7f645f0bc933a944feefd8b0bf92e121e43715b14107dc9b6117d5R746) [[9]](diffhunk://#diff-2621c2002e7f645f0bc933a944feefd8b0bf92e121e43715b14107dc9b6117d5R757)

Overall, these changes make the system's handling of release times more robust and accurate, benefiting both API consumers and end users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RSS pubDate and torrent added_on now use provider release timestamps (UTC-normalized), showing actual release moments.
  * Improved extraction and propagation of release dates from provider HTML/metadata (including STO v2) and availability caches, with sensible fallbacks when only completion times exist.

* **Tests**
  * Added unit and integration tests covering parsing, caching, and end-to-end propagation of release timestamps into torrent adds and RSS pubDate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->