### PR TITLE
feat(hosts): Add dedicated video host registry and refactor downloader flows

### DIFF
--- a/.github/workflows/pr-test-feedback.yml
+++ b/.github/workflows/pr-test-feedback.yml
@@ -11,6 +11,7 @@ permissions:
   actions: read
   contents: read
   issues: write
+  pull-requests: write
 
 concurrency:
   group: pr-test-feedback-${{ github.event.workflow_run.id }}
@@ -131,29 +132,39 @@ jobs:
               comment.user?.type === 'Bot' && comment.body?.includes(marker),
             );
 
-            if (shouldComment) {
+            try {
+              if (shouldComment) {
+                if (existing) {
+                  await github.rest.issues.updateComment({
+                    owner,
+                    repo,
+                    comment_id: existing.id,
+                    body,
+                  });
+                } else {
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number,
+                    body,
+                  });
+                }
+                return;
+              }
+
               if (existing) {
-                await github.rest.issues.updateComment({
+                await github.rest.issues.deleteComment({
                   owner,
                   repo,
                   comment_id: existing.id,
-                  body,
-                });
-              } else {
-                await github.rest.issues.createComment({
-                  owner,
-                  repo,
-                  issue_number,
-                  body,
                 });
               }
-              return;
-            }
-
-            if (existing) {
-              await github.rest.issues.deleteComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-              });
+            } catch (error) {
+              if (error?.status === 403) {
+                core.warning(
+                  `Skipping PR feedback comment sync because the workflow token cannot comment on PR #${issue_number}: ${error.message}`,
+                );
+                return;
+              }
+              throw error;
             }

--- a/.github/workflows/pr-test-feedback.yml
+++ b/.github/workflows/pr-test-feedback.yml
@@ -11,7 +11,6 @@ permissions:
   actions: read
   contents: read
   issues: write
-  pull-requests: write
 
 concurrency:
   group: pr-test-feedback-${{ github.event.workflow_run.id }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,9 @@ Essentials
 - Database: SQLite with Alembic migrations in `apps/api/app/db/migrations`.
 - Use of Context7 for up-to-date external documentation.
 - On change of any environment variable, update `apps/api/.env.example`.
+- Keep the code vocabulary explicit: `providers/` means catalogue sites
+  (`aniworld.to`, `s.to`, `megakino`), while direct video hosts belong under
+  `apps/api/app/hosts/`.
 
 Common pitfalls
 

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -304,12 +304,6 @@ for site in CATALOG_SITES_LIST:
 _default_order = "VOE,Filemoon,Streamtape,Vidmoly,Doodstream,LoadX,Luluvdo,Vidoza"
 _raw = os.getenv("PROVIDER_ORDER", _default_order)
 logger.debug(f"PROVIDER_ORDER raw string: {_raw}")
-
-# Keep the historical PROVIDER_ORDER env var for compatibility, but use
-# "host" internally for the actual video platforms that expose embeds.
-VIDEO_HOST_ORDER = [name.strip() for name in _raw.split(",") if name.strip()]
-PROVIDER_ORDER = VIDEO_HOST_ORDER
-logger.debug(f"VIDEO_HOST_ORDER normalized: {VIDEO_HOST_ORDER}")
 _VALID_VIDEO_HOSTS = {
     "VOE",
     "Vidoza",
@@ -321,13 +315,35 @@ _VALID_VIDEO_HOSTS = {
     "Luluvdo",
     "GXPlayer",
 }
-for host_name in VIDEO_HOST_ORDER:
-    if host_name not in _VALID_VIDEO_HOSTS:
+_VIDEO_HOST_CANONICAL_NAMES = {
+    host_name.lower(): host_name for host_name in _VALID_VIDEO_HOSTS
+}
+
+
+def _normalize_video_host_name(name: str) -> str | None:
+    normalized = name.strip()
+    if not normalized:
+        return None
+    return _VIDEO_HOST_CANONICAL_NAMES.get(normalized.lower())
+
+
+# Keep the historical PROVIDER_ORDER env var for compatibility, but use
+# "host" internally for the actual video platforms that expose embeds.
+VIDEO_HOST_ORDER: list[str] = []
+for configured_name in _raw.split(","):
+    canonical_name = _normalize_video_host_name(configured_name)
+    if canonical_name is not None:
+        VIDEO_HOST_ORDER.append(canonical_name)
+        continue
+    stripped_name = configured_name.strip()
+    if stripped_name:
         logger.warning(
-            "Unknown video host '{}' configured in PROVIDER_ORDER. Valid values: {}",
-            host_name,
+            "Unknown video host '{}' configured in PROVIDER_ORDER; dropping it. Valid values: {}",
+            stripped_name,
             sorted(_VALID_VIDEO_HOSTS),
         )
+PROVIDER_ORDER = VIDEO_HOST_ORDER
+logger.debug(f"VIDEO_HOST_ORDER normalized: {VIDEO_HOST_ORDER}")
 
 # Provider redirect resolution can be slower than direct extractor fetches,
 # especially for VOE after provider-side anti-bot or redirect changes.

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -297,17 +297,20 @@ for site in CATALOG_SITES_LIST:
         continue
     CATALOG_SITE_CONFIGS[site] = deepcopy(base_cfg)
 
-# ---- Provider-Fallback ----
-# Kommagetrennte Liste, z. B. "VOE,Filemoon,Streamtape,Vidmoly,Doodstream,LoadX,Luluvdo,Vidoza"
-# Reihenfolge = Priorität
+# ---- Video-host fallback ----
+# Comma-separated list of direct video hosts, for example:
+# "VOE,Filemoon,Streamtape,Vidmoly,Doodstream,LoadX,Luluvdo,Vidoza"
+# Order = priority.
 _default_order = "VOE,Filemoon,Streamtape,Vidmoly,Doodstream,LoadX,Luluvdo,Vidoza"
 _raw = os.getenv("PROVIDER_ORDER", _default_order)
 logger.debug(f"PROVIDER_ORDER raw string: {_raw}")
 
-# normalisieren: split, trim, nur nicht-leere nehmen, Groß/Kleinschreibung egal
-PROVIDER_ORDER = [p.strip() for p in _raw.split(",") if p.strip()]
-logger.debug(f"PROVIDER_ORDER normalized: {PROVIDER_ORDER}")
-_VALID_PROVIDERS = {
+# Keep the historical PROVIDER_ORDER env var for compatibility, but use
+# "host" internally for the actual video platforms that expose embeds.
+VIDEO_HOST_ORDER = [name.strip() for name in _raw.split(",") if name.strip()]
+PROVIDER_ORDER = VIDEO_HOST_ORDER
+logger.debug(f"VIDEO_HOST_ORDER normalized: {VIDEO_HOST_ORDER}")
+_VALID_VIDEO_HOSTS = {
     "VOE",
     "Vidoza",
     "Doodstream",
@@ -317,12 +320,12 @@ _VALID_PROVIDERS = {
     "LoadX",
     "Luluvdo",
 }
-for provider_name in PROVIDER_ORDER:
-    if provider_name not in _VALID_PROVIDERS:
+for host_name in VIDEO_HOST_ORDER:
+    if host_name not in _VALID_VIDEO_HOSTS:
         logger.warning(
-            "Unknown provider '{}' configured in PROVIDER_ORDER. Valid values: {}",
-            provider_name,
-            sorted(_VALID_PROVIDERS),
+            "Unknown video host '{}' configured in PROVIDER_ORDER. Valid values: {}",
+            host_name,
+            sorted(_VALID_VIDEO_HOSTS),
         )
 
 # Provider redirect resolution can be slower than direct extractor fetches,

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -319,6 +319,7 @@ _VALID_VIDEO_HOSTS = {
     "Streamtape",
     "LoadX",
     "Luluvdo",
+    "GXPlayer",
 }
 for host_name in VIDEO_HOST_ORDER:
     if host_name not in _VALID_VIDEO_HOSTS:

--- a/apps/api/app/core/downloader/__init__.py
+++ b/apps/api/app/core/downloader/__init__.py
@@ -6,11 +6,12 @@ from .download import download_episode  # noqa: E402
 from .episode import build_episode  # noqa: E402
 from .errors import DownloadError, LanguageUnavailableError  # noqa: E402
 from .provider_resolution import get_direct_url_with_fallback  # noqa: E402
-from .types import Language, Provider, ProgressCb  # noqa: E402
+from .types import Host, Language, Provider, ProgressCb  # noqa: E402
 
 __all__ = [
     "DownloadError",
     "LanguageUnavailableError",
+    "Host",
     "Language",
     "Provider",
     "ProgressCb",

--- a/apps/api/app/core/downloader/download.py
+++ b/apps/api/app/core/downloader/download.py
@@ -102,7 +102,7 @@ def download_episode(
             """
             Resolve a Megakino direct URL and download once for one video host.
 
-            Resolves a direct URL for the preferred provider, downloads to
+            Resolves a direct URL for the preferred host, downloads to
             `dest_dir` via yt-dlp, then renames the file to the release schema
             (movie vs episode aware).
 

--- a/apps/api/app/core/downloader/download.py
+++ b/apps/api/app/core/downloader/download.py
@@ -121,9 +121,7 @@ def download_episode(
                 logger.debug("Megakino direct URL already tried; skipping: {}", direct)
                 return None
             tried_direct.add(direct)
-            logger.debug(
-                "Megakino download direct URL: provider={} url={}", chosen, direct
-            )
+            logger.debug("Megakino download direct URL: host={} url={}", chosen, direct)
             base_hint = title_hint
             if not base_hint:
                 if is_movie:

--- a/apps/api/app/core/downloader/download.py
+++ b/apps/api/app/core/downloader/download.py
@@ -31,10 +31,10 @@ def download_episode(
     site: str = "aniworld.to",
 ) -> Path:
     """
-    Download an episode to the specified directory, resolving a direct stream URL with provider fallback logic.
+    Download an episode to the specified directory, resolving a direct stream URL with video-host fallback logic.
 
     This function builds an Episode from the provided identifiers, attempts to
-    resolve a direct download URL (optionally preferring a provider), downloads
+    resolve a direct download URL (optionally preferring a video host), downloads
     the media via yt-dlp with progress callbacks and cancellation support, and
     renames the downloaded file into the repository's release naming schema. If
     extraction or download fails, controlled fallback attempts are performed
@@ -97,17 +97,17 @@ def download_episode(
 
         def _attempt_download(
             *,
-            preferred_provider: Optional[str],
+            preferred_host: Optional[str],
         ) -> Optional[Path]:
             """
-            Resolve Megakino direct URL and download once for one provider.
+            Resolve a Megakino direct URL and download once for one video host.
 
             Resolves a direct URL for the preferred provider, downloads to
             `dest_dir` via yt-dlp, then renames the file to the release schema
             (movie vs episode aware).
 
             Parameters:
-                preferred_provider (Optional[str]): Preferred provider; `None`
+                preferred_host (Optional[str]): Preferred video host; `None`
                     lets the resolver choose.
 
             Returns:
@@ -115,7 +115,7 @@ def download_episode(
                 direct URL was already tried.
             """
             direct, chosen = client.resolve_direct_url(
-                slug=slug, preferred_provider=preferred_provider
+                slug=slug, preferred_host=preferred_host
             )
             if direct in tried_direct:
                 logger.debug("Megakino direct URL already tried; skipping: {}", direct)
@@ -153,16 +153,16 @@ def download_episode(
             logger.success("Final file path: {}", final_path)
             return final_path
 
-        for preferred_provider in provider_candidates:
+        for preferred_host in provider_candidates:
             try:
-                result = _attempt_download(preferred_provider=preferred_provider)
+                result = _attempt_download(preferred_host=preferred_host)
                 if result is not None:
                     return result
             except Exception as exc:
                 last_error = exc
                 logger.warning(
-                    "Megakino download attempt failed (provider={}): {}",
-                    preferred_provider,
+                    "Megakino download attempt failed (host={}): {}",
+                    preferred_host,
                     exc,
                 )
 

--- a/apps/api/app/core/downloader/episode.py
+++ b/apps/api/app/core/downloader/episode.py
@@ -13,6 +13,7 @@ from app.config import (
     PROVIDER_REDIRECT_TIMEOUT_SECONDS,
 )
 from app.core.downloader.extractors import voe as voe_extractor
+from app.hosts import get_host
 from app.utils.aniworld_compat import prepare_aniworld_home
 
 if TYPE_CHECKING:
@@ -403,28 +404,22 @@ class EpisodeCompat:
                 f"Provider '{provider_name}' did not return a redirect URL for {self.link}"
             )
 
-        prepare_aniworld_home()
-        from aniworld.extractors import provider_functions  # type: ignore
         from niquests import RequestException, Timeout  # type: ignore
 
-        extractor = provider_functions.get(
-            f"get_direct_link_from_{provider_name.lower()}"
-        )
-        if extractor is None:
-            raise ValueError(
-                f"The provider '{provider_name}' is not implemented in aniworld>=4."
-            )
+        host = get_host(provider_name)
+        if host is None:
+            raise ValueError(f"The video host '{provider_name}' is not implemented.")
 
         try:
             return _get_direct_link_with_retries(
                 provider_name=provider_name,
                 redirect_url=redirect_url,
-                extractor=extractor,
+                extractor=host.resolve,
                 site=self.site,
             )
         except (Timeout, RequestException, ValueError) as exc:
             raise ValueError(
-                f"Failed to resolve provider '{provider_name}' at {redirect_url}: {exc}"
+                f"Failed to resolve video host '{provider_name}' at {redirect_url}: {exc}"
             ) from exc
 
 

--- a/apps/api/app/core/downloader/provider_resolution.py
+++ b/apps/api/app/core/downloader/provider_resolution.py
@@ -163,7 +163,7 @@ def get_direct_url_with_fallback(
     language: str,
 ) -> Tuple[str, str]:
     """
-    Resolve a direct download URL for an episode, trying a preferred provider first and falling back to the configured provider order.
+    Resolve a direct download URL for an episode, trying a preferred video host first and falling back to the configured host order.
 
     Parameters:
         ep (Episode): Episode object to resolve the direct link for.

--- a/apps/api/app/core/downloader/provider_resolution.py
+++ b/apps/api/app/core/downloader/provider_resolution.py
@@ -167,15 +167,15 @@ def get_direct_url_with_fallback(
 
     Parameters:
         ep (Episode): Episode object to resolve the direct link for.
-        preferred (Optional[str]): Provider name to try first; ignored if empty or None.
+        preferred (Optional[str]): Video host name to try first; ignored if empty or None.
         language (str): Desired language label; will be normalized before use.
 
     Returns:
-        tuple: (direct_url, provider_name) where `direct_url` is the resolved URL and `provider_name` is the provider that supplied it.
+        tuple: (direct_url, host_name) where `direct_url` is the resolved URL and `host_name` is the video host that supplied it.
 
     Raises:
-        LanguageUnavailableError: If the requested language is not offered by the episode or a provider indicates the language is unavailable.
-        DownloadError: If no provider yields a direct URL after all fallbacks.
+        LanguageUnavailableError: If the requested language is not offered by the episode or a host indicates the language is unavailable.
+        DownloadError: If no host yields a direct URL after all fallbacks.
     """
     language = normalize_language(language)
     logger.info(

--- a/apps/api/app/core/downloader/types.py
+++ b/apps/api/app/core/downloader/types.py
@@ -14,6 +14,7 @@ Host = Literal[
     "Streamtape",
     "LoadX",
     "Luluvdo",
+    "GXPlayer",
 ]
 # Backwards-compatible alias used by older downloader call sites.
 Provider = Host

--- a/apps/api/app/core/downloader/types.py
+++ b/apps/api/app/core/downloader/types.py
@@ -4,8 +4,8 @@ from typing import Callable, Literal
 
 # Supported human-readable language labels.
 Language = Literal["German Dub", "German Sub", "English Sub", "English Dub"]
-# Supported provider identifiers in resolver order.
-Provider = Literal[
+# Supported direct video-host identifiers in resolver order.
+Host = Literal[
     "VOE",
     "Vidoza",
     "Doodstream",
@@ -15,5 +15,7 @@ Provider = Literal[
     "LoadX",
     "Luluvdo",
 ]
+# Backwards-compatible alias used by older downloader call sites.
+Provider = Host
 # Callback invoked with yt-dlp progress dictionaries.
 ProgressCb = Callable[[dict], None]

--- a/apps/api/app/core/strm_proxy/resolver.py
+++ b/apps/api/app/core/strm_proxy/resolver.py
@@ -37,7 +37,7 @@ def resolve_direct_url(identity: StrmIdentity) -> tuple[str, str | None]:
         for prov_name in provider_candidates:
             try:
                 direct_url, provider_used = client.resolve_direct_url(
-                    slug=slug, preferred_provider=prov_name
+                    slug=slug, preferred_host=prov_name
                 )
                 logger.debug(
                     "Megakino resolved direct URL provider={} url={}",

--- a/apps/api/app/hosts/__init__.py
+++ b/apps/api/app/hosts/__init__.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from .base import VideoHost
+from .doodstream import HOST as DOODSTREAM
+from .filemoon import HOST as FILEMOON
+from .gxplayer import HOST as GXPLAYER
+from .loadx import HOST as LOADX
+from .luluvdo import HOST as LULUVDO
+from .streamtape import HOST as STREAMTAPE
+from .vidoza import HOST as VIDOZA
+from .vidmoly import HOST as VIDMOLY
+from .voe import HOST as VOE
+
+VIDEO_HOSTS: tuple[VideoHost, ...] = (
+    VOE,
+    DOODSTREAM,
+    FILEMOON,
+    STREAMTAPE,
+    VIDMOLY,
+    LOADX,
+    LULUVDO,
+    VIDOZA,
+    GXPLAYER,
+)
+
+VIDEO_HOSTS_BY_NAME = {host.name: host for host in VIDEO_HOSTS}
+
+
+def get_host(name: str) -> VideoHost | None:
+    """Return one configured video host by its canonical name."""
+    return VIDEO_HOSTS_BY_NAME.get(name)
+
+
+def detect_host(url: str) -> VideoHost | None:
+    """Return the first configured video host matching the given URL."""
+    for host in VIDEO_HOSTS:
+        if host.matches(url):
+            return host
+    return None
+
+
+def resolve_host_url(url: str) -> tuple[str | None, str]:
+    """Resolve a host embed URL and return its canonical host name."""
+    host = detect_host(url)
+    if host is None:
+        return None, "EMBED"
+    return host.resolve(url), host.name
+
+
+def is_supported_host_url(url: str) -> bool:
+    """Return whether any configured video host recognizes the URL."""
+    return detect_host(url) is not None
+
+
+__all__ = [
+    "VIDEO_HOSTS",
+    "VIDEO_HOSTS_BY_NAME",
+    "VideoHost",
+    "detect_host",
+    "get_host",
+    "is_supported_host_url",
+    "resolve_host_url",
+]

--- a/apps/api/app/hosts/base.py
+++ b/apps/api/app/hosts/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Callable, Optional
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 
 
 HostResolver = Callable[[str], Optional[str]]
@@ -18,9 +18,10 @@ class VideoHost:
 
     def matches(self, url: str) -> bool:
         """Return whether this host can handle the given embed URL."""
-        host = urlparse(url).netloc.lower()
+        host = urlsplit(url).hostname
         if not host:
             return False
+        host = host.lower()
         return any(hint in host for hint in self.hints)
 
     def resolve(self, url: str) -> Optional[str]:

--- a/apps/api/app/hosts/base.py
+++ b/apps/api/app/hosts/base.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Optional
+from urllib.parse import urlparse
+
+
+HostResolver = Callable[[str], Optional[str]]
+
+
+@dataclass(frozen=True, slots=True)
+class VideoHost:
+    """Describe one supported video host and how to extract its direct URL."""
+
+    name: str
+    hints: tuple[str, ...]
+    resolver: HostResolver
+
+    def matches(self, url: str) -> bool:
+        """Return whether this host can handle the given embed URL."""
+        host = urlparse(url).netloc.lower()
+        if not host:
+            return False
+        return any(hint in host for hint in self.hints)
+
+    def resolve(self, url: str) -> Optional[str]:
+        """Resolve a host embed URL into a direct media URL."""
+        return self.resolver(url)

--- a/apps/api/app/hosts/bridge.py
+++ b/apps/api/app/hosts/bridge.py
@@ -17,25 +17,21 @@ def resolve_via_aniworld(
 ) -> Optional[str]:
     """Call an upstream aniworld extractor through a thin local host wrapper."""
     prepare_aniworld_home()
+
     try:
         module = import_module(f"aniworld.extractors.provider.{module_name}")
         extractor = getattr(module, function_name)
-        return extractor(url)
-    except Exception as exc:
+    except (ImportError, AttributeError) as exc:
         logger.debug(
             "{} host module import failed for {}: {}; trying provider_functions fallback",
             host_name,
             url,
             exc,
         )
-
-    try:
         extractors_module = import_module("aniworld.extractors")
         provider_functions = getattr(extractors_module, "provider_functions", {})
         extractor = provider_functions.get(function_name)
         if extractor is None:
             return None
-        return extractor(url)
-    except Exception as exc:
-        logger.warning("{} host extraction failed for {}: {}", host_name, url, exc)
-        return None
+
+    return extractor(url)

--- a/apps/api/app/hosts/bridge.py
+++ b/apps/api/app/hosts/bridge.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Optional
+
+from loguru import logger
+
+from app.utils.aniworld_compat import prepare_aniworld_home
+
+
+def resolve_via_aniworld(
+    *,
+    module_name: str,
+    function_name: str,
+    url: str,
+    host_name: str,
+) -> Optional[str]:
+    """Call an upstream aniworld extractor through a thin local host wrapper."""
+    prepare_aniworld_home()
+    try:
+        module = import_module(f"aniworld.extractors.provider.{module_name}")
+        extractor = getattr(module, function_name)
+        return extractor(url)
+    except Exception as exc:
+        logger.debug(
+            "{} host module import failed for {}: {}; trying provider_functions fallback",
+            host_name,
+            url,
+            exc,
+        )
+
+    try:
+        extractors_module = import_module("aniworld.extractors")
+        provider_functions = getattr(extractors_module, "provider_functions", {})
+        extractor = provider_functions.get(function_name)
+        if extractor is None:
+            return None
+        return extractor(url)
+    except Exception as exc:
+        logger.warning("{} host extraction failed for {}: {}", host_name, url, exc)
+        return None

--- a/apps/api/app/hosts/bridge.py
+++ b/apps/api/app/hosts/bridge.py
@@ -40,13 +40,11 @@ def resolve_via_aniworld(
         extractor = getattr(module, function_name)
     except (ImportError, AttributeError) as exc:
         logger.debug(
-            "{} host module import failed for {}: {}; trying provider_functions fallback",
+            "{} host module import failed for {}: {}",
             host_name,
             url,
             exc,
         )
-        extractor = _get_registry_extractor(function_name)
-        if extractor is None:
-            return None
+        return None
 
     return extractor(url)

--- a/apps/api/app/hosts/bridge.py
+++ b/apps/api/app/hosts/bridge.py
@@ -8,6 +8,19 @@ from loguru import logger
 from app.utils.aniworld_compat import prepare_aniworld_home
 
 
+def _get_registry_extractor(function_name: str):
+    try:
+        extractors_module = import_module("aniworld.extractors")
+    except ImportError:
+        return None
+
+    provider_functions = getattr(extractors_module, "provider_functions", {})
+    extractor = provider_functions.get(function_name)
+    if callable(extractor):
+        return extractor
+    return None
+
+
 def resolve_via_aniworld(
     *,
     module_name: str,
@@ -17,6 +30,10 @@ def resolve_via_aniworld(
 ) -> Optional[str]:
     """Call an upstream aniworld extractor through a thin local host wrapper."""
     prepare_aniworld_home()
+
+    extractor = _get_registry_extractor(function_name)
+    if extractor is not None:
+        return extractor(url)
 
     try:
         module = import_module(f"aniworld.extractors.provider.{module_name}")
@@ -28,9 +45,7 @@ def resolve_via_aniworld(
             url,
             exc,
         )
-        extractors_module = import_module("aniworld.extractors")
-        provider_functions = getattr(extractors_module, "provider_functions", {})
-        extractor = provider_functions.get(function_name)
+        extractor = _get_registry_extractor(function_name)
         if extractor is None:
             return None
 

--- a/apps/api/app/hosts/doodstream.py
+++ b/apps/api/app/hosts/doodstream.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from .base import VideoHost
+from .bridge import resolve_via_aniworld
+
+
+HOST = VideoHost(
+    name="Doodstream",
+    hints=("dood", "d0000d"),
+    resolver=lambda url: resolve_via_aniworld(
+        module_name="doodstream",
+        function_name="get_direct_link_from_doodstream",
+        url=url,
+        host_name="Doodstream",
+    ),
+)

--- a/apps/api/app/hosts/filemoon.py
+++ b/apps/api/app/hosts/filemoon.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from .base import VideoHost
+from .bridge import resolve_via_aniworld
+
+
+HOST = VideoHost(
+    name="Filemoon",
+    hints=("filemoon",),
+    resolver=lambda url: resolve_via_aniworld(
+        module_name="filemoon",
+        function_name="get_direct_link_from_filemoon",
+        url=url,
+        host_name="Filemoon",
+    ),
+)

--- a/apps/api/app/hosts/gxplayer.py
+++ b/apps/api/app/hosts/gxplayer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from typing import Optional
+from urllib.parse import quote, urlencode
 
 from loguru import logger
 
@@ -24,18 +25,19 @@ def resolve_gxplayer(url: str) -> Optional[str]:
         logger.warning("GXPlayer host fetch failed: {}", exc)
         return None
 
-    uid_match = re.search(r'"uid":"(.*?)"', response.text)
-    md5_match = re.search(r'"md5":"(.*?)"', response.text)
-    id_match = re.search(r'"id":"(.*?)"', response.text)
+    uid_match = re.search(r'"uid"\s*:\s*"(.*?)"', response.text)
+    md5_match = re.search(r'"md5"\s*:\s*"(.*?)"', response.text)
+    id_match = re.search(r'"id"\s*:\s*"(.*?)"', response.text)
     if not all([uid_match, md5_match, id_match]):
         return None
 
     uid = uid_match.group(1)
     md5 = md5_match.group(1)
     video_id = id_match.group(1)
+    query = urlencode({"s": 1, "id": video_id, "cache": 1})
     return (
-        f"https://watch.gxplayer.xyz/m3u8/{uid}/{md5}/master.txt"
-        f"?s=1&id={video_id}&cache=1"
+        "https://watch.gxplayer.xyz/m3u8/"
+        f"{quote(uid, safe='')}/{quote(md5, safe='')}/master.txt?{query}"
     )
 
 

--- a/apps/api/app/hosts/gxplayer.py
+++ b/apps/api/app/hosts/gxplayer.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from loguru import logger
+
+from app.utils.domain_resolver import get_megakino_base_url
+from app.utils.http_client import get as http_get
+
+from .base import VideoHost
+
+
+def resolve_gxplayer(url: str) -> Optional[str]:
+    """Resolve a gxplayer embed page to the exposed master playlist URL."""
+    logger.debug("GXPlayer direct link probe: {}", url)
+    try:
+        response = http_get(
+            url,
+            timeout=20,
+            headers={"Referer": get_megakino_base_url().rstrip("/")},
+        )
+    except Exception as exc:
+        logger.warning("GXPlayer host fetch failed: {}", exc)
+        return None
+
+    uid_match = re.search(r'"uid":"(.*?)"', response.text)
+    md5_match = re.search(r'"md5":"(.*?)"', response.text)
+    id_match = re.search(r'"id":"(.*?)"', response.text)
+    if not all([uid_match, md5_match, id_match]):
+        return None
+
+    uid = uid_match.group(1)
+    md5 = md5_match.group(1)
+    video_id = id_match.group(1)
+    return (
+        f"https://watch.gxplayer.xyz/m3u8/{uid}/{md5}/master.txt"
+        f"?s=1&id={video_id}&cache=1"
+    )
+
+
+HOST = VideoHost(
+    name="GXPlayer",
+    hints=("gxplayer",),
+    resolver=resolve_gxplayer,
+)

--- a/apps/api/app/hosts/loadx.py
+++ b/apps/api/app/hosts/loadx.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from .base import VideoHost
+from .bridge import resolve_via_aniworld
+
+
+HOST = VideoHost(
+    name="LoadX",
+    hints=("loadx",),
+    resolver=lambda url: resolve_via_aniworld(
+        module_name="loadx",
+        function_name="get_direct_link_from_loadx",
+        url=url,
+        host_name="LoadX",
+    ),
+)

--- a/apps/api/app/hosts/luluvdo.py
+++ b/apps/api/app/hosts/luluvdo.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from .base import VideoHost
+from .bridge import resolve_via_aniworld
+
+
+HOST = VideoHost(
+    name="Luluvdo",
+    hints=("luluvdo",),
+    resolver=lambda url: resolve_via_aniworld(
+        module_name="luluvdo",
+        function_name="get_direct_link_from_luluvdo",
+        url=url,
+        host_name="Luluvdo",
+    ),
+)

--- a/apps/api/app/hosts/streamtape.py
+++ b/apps/api/app/hosts/streamtape.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from .base import VideoHost
+from .bridge import resolve_via_aniworld
+
+
+HOST = VideoHost(
+    name="Streamtape",
+    hints=("streamtape", "streamta.pe"),
+    resolver=lambda url: resolve_via_aniworld(
+        module_name="streamtape",
+        function_name="get_direct_link_from_streamtape",
+        url=url,
+        host_name="Streamtape",
+    ),
+)

--- a/apps/api/app/hosts/vidmoly.py
+++ b/apps/api/app/hosts/vidmoly.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from .base import VideoHost
+from .bridge import resolve_via_aniworld
+
+
+HOST = VideoHost(
+    name="Vidmoly",
+    hints=("vidmoly",),
+    resolver=lambda url: resolve_via_aniworld(
+        module_name="vidmoly",
+        function_name="get_direct_link_from_vidmoly",
+        url=url,
+        host_name="Vidmoly",
+    ),
+)

--- a/apps/api/app/hosts/vidoza.py
+++ b/apps/api/app/hosts/vidoza.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from .base import VideoHost
+from .bridge import resolve_via_aniworld
+
+
+HOST = VideoHost(
+    name="Vidoza",
+    hints=("vidoza",),
+    resolver=lambda url: resolve_via_aniworld(
+        module_name="vidoza",
+        function_name="get_direct_link_from_vidoza",
+        url=url,
+        host_name="Vidoza",
+    ),
+)

--- a/apps/api/app/hosts/voe.py
+++ b/apps/api/app/hosts/voe.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from .base import VideoHost
+from .bridge import resolve_via_aniworld
+
+
+HOST = VideoHost(
+    name="VOE",
+    hints=("voe",),
+    resolver=lambda url: resolve_via_aniworld(
+        module_name="voe",
+        function_name="get_direct_link_from_voe",
+        url=url,
+        host_name="VOE",
+    ),
+)

--- a/apps/api/app/providers/__init__.py
+++ b/apps/api/app/providers/__init__.py
@@ -1,4 +1,4 @@
-"""Provider implementations."""
+"""Catalogue site provider implementations."""
 
 from typing import Optional
 

--- a/apps/api/app/providers/megakino/client.py
+++ b/apps/api/app/providers/megakino/client.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 from bs4 import BeautifulSoup  # type: ignore
 from loguru import logger
 
-from app.utils.aniworld_compat import prepare_aniworld_home
+from app.hosts import detect_host, resolve_host_url
 from app.utils.http_client import get as http_get
 from app.utils.domain_resolver import get_megakino_base_url
 from app.config import MEGAKINO_TITLES_REFRESH_HOURS
@@ -29,24 +29,10 @@ _MEGAKINO_TOKEN_LOCK = threading.Lock()
 _MEGAKINO_TOKEN_AT = 0.0
 _MEGAKINO_TOKEN_TTL_SECONDS = 30 * 60
 _DEFAULT_CLIENT_LOCK = threading.Lock()
-_MEGAKINO_PROVIDER_HOSTS = (
-    "voe",
-    "dood",
-    "d0000d",
-    "filemoon",
-    "streamtape",
-    "streamta.pe",
-    "vidmoly",
-    "speedfiles",
-    "loadx",
-    "luluvdo",
-    "vidoza",
-    "gxplayer",
-)
 
 
 def _is_disabled_provider_url(url: str) -> bool:
-    """Return whether a provider URL points to a disabled extractor host."""
+    """Return whether a host URL points to a disabled extractor host."""
 
     return "speedfiles" in urlparse(url).netloc.lower()
 
@@ -156,17 +142,22 @@ class MegakinoClient:
         return None
 
     def resolve_direct_url(
-        self, slug: str, preferred_provider: Optional[str] = None
+        self,
+        slug: str,
+        preferred_host: Optional[str] = None,
+        *,
+        preferred_provider: Optional[str] = None,
     ) -> Tuple[str, str]:
         """
-        Resolve a direct media URL and its provider name for a given Megakino slug.
+        Resolve a direct media URL and its host name for a given Megakino slug.
 
         Parameters:
             slug (str): Megakino page slug to resolve.
-            preferred_provider (Optional[str]): Optional provider identifier to prefer when multiple providers are available.
+            preferred_host (Optional[str]): Optional video-host identifier to prefer when multiple embeds are available.
+            preferred_provider (Optional[str]): Deprecated alias for `preferred_host`.
 
         Returns:
-            tuple: (`url`, `provider_name`) where `url` is the direct media URL (or an iframe URL fallback) and `provider_name` is the inferred provider label (for example, `"EMBED"`).
+            tuple: (`url`, `host_name`) where `url` is the direct media URL (or an iframe URL fallback) and `host_name` is the inferred video-host label (for example, `"EMBED"`).
 
         Raises:
             ValueError: If the slug does not map to a Megakino page, if no provider iframes are found, or if no provider yields a resolvable URL.
@@ -183,54 +174,65 @@ class MegakinoClient:
             headers=_megakino_headers(referer=base_url),
         )
         resp.raise_for_status()
-        providers = [
+        host_urls = [
             url
             for url in _extract_provider_links(resp.text)
             if not _is_disabled_provider_url(url)
         ]
-        if not providers:
-            raise ValueError("No provider iframes found on megakino page")
-        logger.debug("Megakino providers extracted: {}", providers)
+        if not host_urls:
+            raise ValueError("No video host iframes found on megakino page")
+        logger.debug("Megakino video hosts extracted: {}", host_urls)
 
-        preferred = (preferred_provider or "").lower()
-        ordered = providers
+        preferred_name = preferred_host or preferred_provider
+        preferred = (preferred_name or "").lower()
+        ordered = host_urls
         if preferred:
             ordered = sorted(
-                providers,
+                host_urls,
                 key=lambda url: 0 if preferred in url.lower() else 1,
             )
 
         for url in ordered:
-            direct = _extract_provider_direct(url)
+            direct, host_name = resolve_host_url(url)
             if direct:
                 logger.debug("Megakino direct link resolved via '{}'", url)
-                return direct, _provider_name_from_url(url)
-            logger.debug("Megakino extractor did not return direct URL for '{}'", url)
+                return direct, host_name
+            logger.debug(
+                "Megakino host resolver did not return a direct URL for '{}'", url
+            )
 
         # Fallback to first iframe URL for yt-dlp to try if supported.
-        if providers:
-            fallback = _normalize_url(providers[0])
+        if host_urls:
+            fallback = _normalize_url(host_urls[0])
             logger.debug("Megakino fallback to iframe URL '{}'", fallback)
             return fallback, "EMBED"
 
-        raise ValueError("No direct megakino provider URL resolved")
+        raise ValueError("No direct megakino host URL resolved")
 
 
 def resolve_direct_url(
-    slug: str, preferred_provider: Optional[str] = None
+    slug: str,
+    preferred_host: Optional[str] = None,
+    *,
+    preferred_provider: Optional[str] = None,
 ) -> Tuple[str, str]:
     """
     Resolve a slug to a direct media URL using the default shared MegakinoClient.
 
     Parameters:
         slug (str): Megakino slug identifying the media page.
-        preferred_provider (Optional[str]): Optional provider name to prefer when multiple providers are available.
+        preferred_host (Optional[str]): Optional video-host name to prefer when multiple embeds are available.
+        preferred_provider (Optional[str]): Deprecated alias for `preferred_host`.
 
     Returns:
-        Tuple[str, str]: A tuple containing the resolved direct media URL and the provider label used (e.g., `"EMBED"` when falling back to an embed URL).
+        Tuple[str, str]: A tuple containing the resolved direct media URL and the host label used (e.g., `"EMBED"` when falling back to an embed URL).
     """
     client = get_default_client()
-    return client.resolve_direct_url(slug, preferred_provider=preferred_provider)
+    return client.resolve_direct_url(
+        slug,
+        preferred_host=preferred_host,
+        preferred_provider=preferred_provider,
+    )
 
 
 def time_now() -> float:
@@ -330,10 +332,10 @@ def _extract_provider_links(html: str) -> List[str]:
             _add_link(src)
 
     if links:
-        provider_links = [
+        host_links = [
             link for link in links if _looks_like_provider_url(_normalize_url(link))
         ]
-        return provider_links or links
+        return host_links or links
 
     for attr in ("data-src", "data-iframe", "data-embed", "data-player"):
         for tag in soup.find_all(attrs={attr: True}):
@@ -352,10 +354,7 @@ def _extract_provider_links(html: str) -> List[str]:
 
 
 def _looks_like_provider_url(url: str) -> bool:
-    host = urlparse(url).netloc.lower()
-    if not host:
-        return False
-    return any(hint in host for hint in _MEGAKINO_PROVIDER_HOSTS)
+    return detect_host(url) is not None or "speedfiles" in urlparse(url).netloc.lower()
 
 
 def _megakino_headers(*, referer: Optional[str] = None) -> Dict[str, str]:
@@ -389,148 +388,6 @@ def _warm_megakino_session(base_url: str) -> None:
             logger.debug("Megakino token request ok")
         except Exception as exc:
             logger.debug("Megakino token request failed: {}", exc)
-
-
-def _megakino_get_direct_link(link: str) -> Optional[str]:
-    """
-    Probe a Megakino provider page and construct a gxplayer direct media URL when the page exposes the required identifiers.
-
-    Parameters:
-        link (str): URL of the provider page to fetch and inspect.
-
-    Returns:
-        str: Constructed gxplayer m3u8 URL when `uid`, `md5`, and `id` are present in the page, `None` otherwise.
-    """
-    logger.debug("Megakino direct link probe: {}", link)
-    try:
-        resp = http_get(
-            link,
-            timeout=20,
-            headers=_megakino_headers(referer=get_megakino_base_url().rstrip("/")),
-        )
-    except Exception as exc:
-        logger.warning("Megakino provider fetch failed: {}", exc)
-        return None
-    uid_match = re.search(r'"uid":"(.*?)"', resp.text)
-    md5_match = re.search(r'"md5":"(.*?)"', resp.text)
-    id_match = re.search(r'"id":"(.*?)"', resp.text)
-    if not all([uid_match, md5_match, id_match]):
-        return None
-    uid = uid_match.group(1)
-    md5 = md5_match.group(1)
-    video_id = id_match.group(1)
-    return f"https://watch.gxplayer.xyz/m3u8/{uid}/{md5}/master.txt?s=1&id={video_id}&cache=1"
-
-
-def _provider_name_from_url(url: str) -> str:
-    """
-    Infer the canonical provider name from a provider or embed URL.
-
-    Parameters:
-        url (str): The provider or iframe URL to inspect.
-
-    Returns:
-        provider_name (str): One of the known provider identifiers (e.g., "VOE", "Doodstream", "Filemoon", "Streamtape", "Vidmoly", "LoadX", "Luluvdo", "Vidoza"; `SpeedFiles` is detected but extraction is disabled); returns "EMBED" if no known provider is detected.
-    """
-    host = urlparse(url).netloc.lower()
-    if "voe" in host:
-        return "VOE"
-    if "dood" in host or "d0000d" in host:
-        return "Doodstream"
-    if "filemoon" in host:
-        return "Filemoon"
-    if "streamtape" in host or "streamta.pe" in host:
-        return "Streamtape"
-    if "vidmoly" in host:
-        return "Vidmoly"
-    if "speedfiles" in host:
-        return "SpeedFiles"
-    if "loadx" in host:
-        return "LoadX"
-    if "luluvdo" in host:
-        return "Luluvdo"
-    if "vidoza" in host:
-        return "Vidoza"
-    return "EMBED"
-
-
-def _extract_provider_direct(url: str) -> Optional[str]:
-    """
-    Determine and return a direct media URL for a provider iframe URL by selecting and invoking a provider-specific extractor.
-
-    The function inspects the host part of `url` to choose a provider extractor (e.g., Voe, Doodstream, Filemoon, Streamtape, Vidmoly, Loadx, Luluvdo, Vidoza). If a matching extractor is available it is imported and called; if the host contains "gxplayer" a legacy GXPlayer extraction is attempted. Any extraction error is caught and results in `None`.
-
-    Parameters:
-        url (str): The provider iframe URL to resolve.
-
-    Returns:
-        str | None: The direct media URL produced by the provider extractor, or `None` if no extractor matches or extraction fails.
-    """
-    host = urlparse(url).netloc.lower()
-    prepare_aniworld_home()
-    try:
-        if "voe" in host:
-            from aniworld.extractors.provider.voe import (  # type: ignore
-                get_direct_link_from_voe,
-            )
-
-            return get_direct_link_from_voe(url)
-        if "dood" in host or "d0000d" in host:
-            from aniworld.extractors.provider.doodstream import (  # type: ignore
-                get_direct_link_from_doodstream,
-            )
-
-            return get_direct_link_from_doodstream(url)
-        if "filemoon" in host:
-            from aniworld.extractors.provider.filemoon import (  # type: ignore
-                get_direct_link_from_filemoon,
-            )
-
-            return get_direct_link_from_filemoon(url)
-        if "streamtape" in host or "streamta.pe" in host:
-            from aniworld.extractors.provider.streamtape import (  # type: ignore
-                get_direct_link_from_streamtape,
-            )
-
-            return get_direct_link_from_streamtape(url)
-        if "vidmoly" in host:
-            from aniworld.extractors.provider.vidmoly import (  # type: ignore
-                get_direct_link_from_vidmoly,
-            )
-
-            return get_direct_link_from_vidmoly(url)
-        if "speedfiles" in host:
-            logger.warning(
-                "SpeedFiles extractor was removed from aniworld>=4; skipping {}",
-                url,
-            )
-            return None
-        if "loadx" in host:
-            from aniworld.extractors.provider.loadx import (  # type: ignore
-                get_direct_link_from_loadx,
-            )
-
-            return get_direct_link_from_loadx(url)
-        if "luluvdo" in host:
-            from aniworld.extractors.provider.luluvdo import (  # type: ignore
-                get_direct_link_from_luluvdo,
-            )
-
-            return get_direct_link_from_luluvdo(url)
-        if "vidoza" in host:
-            from aniworld.extractors.provider.vidoza import (  # type: ignore
-                get_direct_link_from_vidoza,
-            )
-
-            return get_direct_link_from_vidoza(url)
-    except Exception as exc:
-        logger.warning("Megakino provider extraction failed for {}: {}", url, exc)
-        return None
-    # Try the legacy gxplayer extractor for direct links if present.
-    if "gxplayer" in host:
-        direct = _megakino_get_direct_link(url)
-        return direct
-    return None
 
 
 _DEFAULT_CLIENT: Optional[MegakinoClient] = None

--- a/apps/api/app/providers/megakino/client.py
+++ b/apps/api/app/providers/megakino/client.py
@@ -32,7 +32,7 @@ _MEGAKINO_TOKEN_TTL_SECONDS = 30 * 60
 _DEFAULT_CLIENT_LOCK = threading.Lock()
 
 
-def _is_disabled_provider_url(url: str) -> bool:
+def _is_disabled_host_url(url: str) -> bool:
     """Return whether a host URL points to a disabled extractor host."""
 
     return "speedfiles" in urlparse(url).netloc.lower()
@@ -185,19 +185,19 @@ class MegakinoClient:
         resp.raise_for_status()
         host_urls = [
             url
-            for url in _extract_provider_links(resp.text)
-            if not _is_disabled_provider_url(url)
+            for url in _extract_host_links(resp.text)
+            if not _is_disabled_host_url(url)
         ]
         if not host_urls:
             raise ValueError("No video host iframes found on megakino page")
         logger.debug("Megakino video hosts extracted: {}", host_urls)
 
-        preferred = (preferred_host or "").lower()
+        preferred = _normalize_host_preference(preferred_host)
         ordered = host_urls
         if preferred:
             ordered = sorted(
                 host_urls,
-                key=lambda url: 0 if preferred in url.lower() else 1,
+                key=lambda url: 0 if preferred in _host_match_candidates(url) else 1,
             )
 
         for url in ordered:
@@ -210,8 +210,8 @@ class MegakinoClient:
             )
 
         # Fallback to first iframe URL for yt-dlp to try if supported.
-        if host_urls:
-            fallback = _normalize_url(host_urls[0])
+        if ordered:
+            fallback = _normalize_url(ordered[0])
             logger.debug("Megakino fallback to iframe URL '{}'", fallback)
             return fallback, "EMBED"
 
@@ -312,7 +312,7 @@ def _score_tokens(query_tokens: List[str], title_tokens: List[str]) -> int:
     return len(intersection)
 
 
-def _extract_provider_links(html: str) -> List[str]:
+def _extract_host_links(html: str) -> List[str]:
     """
     Extract iframe provider URLs from the given HTML.
 
@@ -320,7 +320,7 @@ def _extract_provider_links(html: str) -> List[str]:
         html (str): HTML content to parse.
 
     Returns:
-        List[str]: Provider URLs extracted from iframe `data-src` or `src` attributes, in document order.
+        List[str]: Host URLs extracted from iframe `data-src` or `src` attributes, in document order.
     """
     soup = BeautifulSoup(html, "html.parser")
     links: List[str] = []
@@ -341,28 +341,55 @@ def _extract_provider_links(html: str) -> List[str]:
 
     if links:
         host_links = [
-            link for link in links if _looks_like_provider_url(_normalize_url(link))
+            link for link in links if _looks_like_host_url(_normalize_url(link))
         ]
         return host_links or links
 
     for attr in ("data-src", "data-iframe", "data-embed", "data-player"):
         for tag in soup.find_all(attrs={attr: True}):
             candidate = tag.get(attr)
-            if candidate and _looks_like_provider_url(_normalize_url(candidate)):
+            if candidate and _looks_like_host_url(_normalize_url(candidate)):
                 _add_link(candidate)
 
     if links:
         return links
 
     for match in re.findall(r"https?://[^\s'\"<>]+", html):
-        if _looks_like_provider_url(match):
+        if _looks_like_host_url(match):
             _add_link(match)
 
     return links
 
 
-def _looks_like_provider_url(url: str) -> bool:
+def _looks_like_host_url(url: str) -> bool:
     return detect_host(url) is not None or "speedfiles" in urlparse(url).netloc.lower()
+
+
+def _normalize_host_preference(preferred_host: Optional[str]) -> str:
+    if not preferred_host:
+        return ""
+    preferred = preferred_host.strip().lower()
+    if not preferred:
+        return ""
+    parsed = urlparse(preferred if "://" in preferred else f"https://{preferred}")
+    return (parsed.hostname or preferred).lower().strip(".")
+
+
+def _host_match_candidates(url: str) -> set[str]:
+    normalized_url = _normalize_url(url)
+    parsed = urlparse(normalized_url)
+    hostname = (parsed.hostname or "").lower().strip(".")
+    candidates: set[str] = set()
+    if hostname:
+        candidates.add(hostname)
+        candidates.add(hostname.removeprefix("www."))
+        parts = hostname.split(".")
+        if len(parts) >= 2:
+            candidates.add(".".join(parts[-2:]))
+    detected_host = detect_host(normalized_url)
+    if detected_host is not None:
+        candidates.add(detected_host.name.lower())
+    return {candidate for candidate in candidates if candidate}
 
 
 def _megakino_headers(*, referer: Optional[str] = None) -> Dict[str, str]:

--- a/apps/api/app/providers/megakino/client.py
+++ b/apps/api/app/providers/megakino/client.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional, Tuple
 import threading
 import re
 import time
+import warnings
 from urllib.parse import urlparse
 
 from bs4 import BeautifulSoup  # type: ignore
@@ -160,8 +161,16 @@ class MegakinoClient:
             tuple: (`url`, `host_name`) where `url` is the direct media URL (or an iframe URL fallback) and `host_name` is the inferred video-host label (for example, `"EMBED"`).
 
         Raises:
-            ValueError: If the slug does not map to a Megakino page, if no provider iframes are found, or if no provider yields a resolvable URL.
+            ValueError: If the slug does not map to a Megakino page, if no video-host iframes are found, or if no video host yields a resolvable URL.
         """
+        if preferred_host is None and preferred_provider is not None:
+            warnings.warn(
+                "preferred_provider is deprecated; use preferred_host instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            preferred_host = preferred_provider
+
         page_url = self.resolve_url(slug)
         if not page_url:
             raise ValueError(f"Megakino page not found for slug '{slug}'")
@@ -183,8 +192,7 @@ class MegakinoClient:
             raise ValueError("No video host iframes found on megakino page")
         logger.debug("Megakino video hosts extracted: {}", host_urls)
 
-        preferred_name = preferred_host or preferred_provider
-        preferred = (preferred_name or "").lower()
+        preferred = (preferred_host or "").lower()
         ordered = host_urls
         if preferred:
             ordered = sorted(

--- a/apps/api/app/utils/probe_quality.py
+++ b/apps/api/app/utils/probe_quality.py
@@ -67,7 +67,7 @@ def probe_episode_quality(
         season (int): Season number.
         episode (int): Episode number.
         language (str): Desired audio/subtitle language code.
-        preferred_provider (Optional[str]): Provider to try first, if any.
+        preferred_provider (Optional[str]): Video host to try first, if any.
         timeout (float): Socket/metadata probe timeout in seconds.
         site (str): Site identifier used when building the episode object.
 
@@ -87,7 +87,7 @@ def probe_episode_quality(
         try:
             client = get_default_client()
             direct, provider_used = client.resolve_direct_url(
-                slug=slug, preferred_provider=preferred_provider
+                slug=slug, preferred_host=preferred_provider
             )
         except Exception as exc:
             logger.warning(

--- a/apps/api/app/utils/probe_quality.py
+++ b/apps/api/app/utils/probe_quality.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import Optional, Dict, Any, List, cast
+import warnings
 from loguru import logger
 import yt_dlp
 
@@ -55,39 +56,49 @@ def probe_episode_quality(
     season: int,
     episode: int,
     language: str,
+    preferred_host: Optional[str] = None,
     preferred_provider: Optional[str] = None,
     timeout: float = 6.0,
     site: str = "aniworld.to",
 ) -> tuple[bool, Optional[int], Optional[str], Optional[str], Dict[str, Any] | None]:
     """
-    Probe whether an episode is available in the requested language and return the provider used along with reported video quality.
+    Probe whether an episode is available in the requested language and return the host used along with reported video quality.
 
     Parameters:
         slug (str): Episode identifier (series slug).
         season (int): Season number.
         episode (int): Episode number.
         language (str): Desired audio/subtitle language code.
-        preferred_provider (Optional[str]): Video host to try first, if any.
+        preferred_host (Optional[str]): Video host to try first, if any.
+        preferred_provider (Optional[str]): Deprecated alias for `preferred_host`.
         timeout (float): Socket/metadata probe timeout in seconds.
         site (str): Site identifier used when building the episode object.
 
     Returns:
         tuple[bool, Optional[int], Optional[str], Optional[str], Dict[str, Any] | None]:
-            - available (bool): True if a provider yielded playable metadata for the requested language, False otherwise.
+            - available (bool): True if a host yielded playable metadata for the requested language, False otherwise.
             - height (Optional[int]): Reported video height in pixels, or None if unavailable.
             - vcodec (Optional[str]): Reported video codec string, or None if unavailable.
-            - provider_used (Optional[str]): Name of the provider that succeeded, or None if none succeeded.
+            - host_used (Optional[str]): Name of the video host that succeeded, or None if none succeeded.
             - raw_info (Dict[str, Any] | None): Raw metadata returned by the probe, or None if unavailable.
     """
+    if preferred_host is None and preferred_provider is not None:
+        warnings.warn(
+            "preferred_provider is deprecated; use preferred_host instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        preferred_host = preferred_provider
+
     logger.info(
         f"Probing episode quality for slug={slug}, season={season}, episode={episode}, language={language}, "
-        f"preferred_provider={preferred_provider}, timeout={timeout}, site={site}"
+        f"preferred_host={preferred_host}, timeout={timeout}, site={site}"
     )
     if "megakino" in site:
         try:
             client = get_default_client()
             direct, provider_used = client.resolve_direct_url(
-                slug=slug, preferred_host=preferred_provider
+                slug=slug, preferred_host=preferred_host
             )
         except Exception as exc:
             logger.warning(
@@ -111,32 +122,32 @@ def probe_episode_quality(
     ep = build_episode(slug=slug, season=season, episode=episode, site=site)
     logger.debug(f"Built episode object: {ep}")
     candidates: List[str] = []
-    if preferred_provider:
-        candidates.append(preferred_provider)
-        logger.debug(f"Preferred provider added: {preferred_provider}")
+    if preferred_host:
+        candidates.append(preferred_host)
+        logger.debug(f"Preferred host added: {preferred_host}")
     for p in PROVIDER_ORDER:
         if p not in candidates:
             candidates.append(p)
-    logger.debug(f"Provider candidates: {candidates}")
+    logger.debug(f"Host candidates: {candidates}")
     for prov in candidates:
-        logger.info(f"Trying provider: {prov}")
+        logger.info(f"Trying host: {prov}")
         try:
             direct, chosen = get_direct_url_with_fallback(
                 ep, preferred=prov, language=language
             )
-            logger.debug(f"Got direct URL: {direct} (chosen provider: {chosen})")
+            logger.debug(f"Got direct URL: {direct} (chosen host: {chosen})")
             h, vc, info = probe_episode_quality_once(direct, timeout=timeout)
             logger.info(
-                f"Provider '{chosen}' succeeded: available=True, height={h}, vcodec={vc}"
+                f"Host '{chosen}' succeeded: available=True, height={h}, vcodec={vc}"
             )
             return (True, h, vc, chosen, info)
         except Exception as e:
             logger.warning(
-                "Provider '{}' failed ({}): {}",
+                "Host '{}' failed ({}): {}",
                 prov,
                 type(e).__name__,
                 e,
             )
             continue
-    logger.error("No provider succeeded for this episode/language.")
+    logger.error("No host succeeded for this episode/language.")
     return (False, None, None, None, None)

--- a/apps/api/tests/unit/app/test_config.py
+++ b/apps/api/tests/unit/app/test_config.py
@@ -14,6 +14,22 @@ def test_provider_order_parsing(monkeypatch):
     assert cfg.PROVIDER_ORDER == ["VOE", "Filemoon", "Streamtape"]
 
 
+def test_provider_order_normalizes_case_and_drops_invalid(monkeypatch):
+    monkeypatch.setenv("PROVIDER_ORDER", " voe , filemoon,invalid,gxplayer ")
+    import importlib
+    import sys
+    import app
+
+    if "app.config" in sys.modules:
+        del sys.modules["app.config"]
+    if hasattr(app, "config"):
+        delattr(app, "config")
+    cfg = importlib.import_module("app.config")
+
+    assert cfg.VIDEO_HOST_ORDER == ["VOE", "Filemoon", "GXPlayer"]
+    assert cfg.PROVIDER_ORDER == ["VOE", "Filemoon", "GXPlayer"]
+
+
 def test_repo_root_defaults_anchor_local_data_paths() -> None:
     import app.config as cfg
 

--- a/apps/api/tests/unit/hosts/test_registry.py
+++ b/apps/api/tests/unit/hosts/test_registry.py
@@ -1,13 +1,155 @@
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+import app.hosts as host_registry
 from app.hosts import detect_host, resolve_host_url
+from app.hosts.base import VideoHost
+from app.hosts.bridge import resolve_via_aniworld
+from app.hosts.gxplayer import resolve_gxplayer
+
+
+REPRESENTATIVE_URLS = {
+    "VOE": "https://voe.sx/e/abc123",
+    "Doodstream": "https://doodstream.com/e/abc123",
+    "Filemoon": "https://filemoon.sx/e/abc123",
+    "Streamtape": "https://streamtape.com/e/abc123",
+    "Vidmoly": "https://vidmoly.to/embed-abc123.html",
+    "LoadX": "https://loadx.to/embed/abc123",
+    "Luluvdo": "https://luluvdo.com/e/abc123",
+    "Vidoza": "https://vidoza.net/embed-abc123",
+    "GXPlayer": "https://watch.gxplayer.xyz/embed/abc123",
+}
 
 
 def test_detect_host_matches_known_embed_domain():
-    host = detect_host("https://voe.sx/e/abc123")
+    host = detect_host(REPRESENTATIVE_URLS["VOE"])
     assert host is not None
     assert host.name == "VOE"
+
+
+def test_detect_host_ignores_userinfo_host_confusion():
+    host = detect_host("https://voe.sx@evil.example/embed/abc123")
+    assert host is None
 
 
 def test_resolve_host_url_returns_embed_when_unknown():
     direct_url, host_name = resolve_host_url("https://example.invalid/embed/123")
     assert direct_url is None
     assert host_name == "EMBED"
+
+
+@pytest.mark.parametrize("host_name, url", sorted(REPRESENTATIVE_URLS.items()))
+def test_registry_hosts_are_discoverable(host_name: str, url: str):
+    host = detect_host(url)
+    assert host is not None
+    assert host.name == host_name
+
+
+def test_resolve_host_url_uses_registry(monkeypatch):
+    fake_hosts = tuple(
+        VideoHost(
+            name=host.name,
+            hints=host.hints,
+            resolver=lambda url, *, expected=host.name: f"https://direct/{expected}",
+        )
+        for host in host_registry.VIDEO_HOSTS
+    )
+    monkeypatch.setattr(host_registry, "VIDEO_HOSTS", fake_hosts)
+    monkeypatch.setattr(
+        host_registry,
+        "VIDEO_HOSTS_BY_NAME",
+        {host.name: host for host in fake_hosts},
+    )
+
+    for host_name, url in REPRESENTATIVE_URLS.items():
+        direct_url, resolved_name = resolve_host_url(url)
+        assert direct_url == f"https://direct/{host_name}"
+        assert resolved_name == host_name
+
+
+def test_resolve_via_aniworld_falls_back_to_provider_functions(monkeypatch):
+    def fake_import_module(name: str):
+        if name == "aniworld.extractors.provider.voe":
+            raise ImportError("missing provider module")
+        if name == "aniworld.extractors":
+
+            class ExtractorsModule:
+                provider_functions = {
+                    "get_direct_link_from_voe": lambda url: f"{url}/fallback"
+                }
+
+            return ExtractorsModule()
+        raise AssertionError(f"unexpected module import: {name}")
+
+    monkeypatch.setattr("app.hosts.bridge.prepare_aniworld_home", lambda: None)
+    monkeypatch.setattr("app.hosts.bridge.import_module", fake_import_module)
+
+    resolved = resolve_via_aniworld(
+        module_name="voe",
+        function_name="get_direct_link_from_voe",
+        url="https://voe.sx/e/abc123",
+        host_name="VOE",
+    )
+
+    assert resolved == "https://voe.sx/e/abc123/fallback"
+
+
+def test_resolve_via_aniworld_propagates_extractor_errors(monkeypatch):
+    class ProviderModule:
+        @staticmethod
+        def get_direct_link_from_voe(url: str) -> str:
+            raise ValueError(f"boom: {url}")
+
+    monkeypatch.setattr("app.hosts.bridge.prepare_aniworld_home", lambda: None)
+    monkeypatch.setattr(
+        "app.hosts.bridge.import_module",
+        lambda name: (
+            ProviderModule() if name == "aniworld.extractors.provider.voe" else None
+        ),
+    )
+
+    with pytest.raises(ValueError, match="boom: https://voe.sx/e/abc123"):
+        resolve_via_aniworld(
+            module_name="voe",
+            function_name="get_direct_link_from_voe",
+            url="https://voe.sx/e/abc123",
+            host_name="VOE",
+        )
+
+
+def test_resolve_gxplayer_accepts_whitespace_and_encodes_values(monkeypatch):
+    response = type(
+        "Response",
+        (),
+        {
+            "text": '{ "uid" : "uid/with space", "md5" : "hash+slash/", "id" : "video id" }'
+        },
+    )()
+    monkeypatch.setattr(
+        "app.hosts.gxplayer.get_megakino_base_url", lambda: "https://megakino.example"
+    )
+    monkeypatch.setattr("app.hosts.gxplayer.http_get", lambda *args, **kwargs: response)
+
+    resolved = resolve_gxplayer("https://watch.gxplayer.xyz/embed/abc123")
+
+    assert resolved == (
+        "https://watch.gxplayer.xyz/m3u8/uid%2Fwith%20space/hash%2Bslash%2F/master.txt"
+        "?s=1&id=video+id&cache=1"
+    )
+
+
+def test_megakino_client_warns_for_preferred_provider_alias(monkeypatch):
+    from app.providers.megakino.client import MegakinoClient
+
+    client = MegakinoClient(sitemap_url="http://example.com", refresh_hours=0.0)
+    monkeypatch.setattr(client, "resolve_url", lambda slug: None)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(ValueError, match="Megakino page not found"):
+            client.resolve_direct_url("slug", preferred_provider="VOE")
+
+    assert any(item.category is DeprecationWarning for item in caught)

--- a/apps/api/tests/unit/hosts/test_registry.py
+++ b/apps/api/tests/unit/hosts/test_registry.py
@@ -97,6 +97,37 @@ def test_resolve_via_aniworld_falls_back_to_provider_functions(monkeypatch):
     assert resolved == "https://voe.sx/e/abc123/fallback"
 
 
+def test_resolve_via_aniworld_prefers_provider_function_registry(monkeypatch):
+    class ExtractorsModule:
+        provider_functions = {"get_direct_link_from_voe": lambda url: f"{url}/registry"}
+
+    class ProviderModule:
+        @staticmethod
+        def get_direct_link_from_voe(url: str) -> str:
+            return f"{url}/module"
+
+    monkeypatch.setattr("app.hosts.bridge.prepare_aniworld_home", lambda: None)
+    monkeypatch.setattr(
+        "app.hosts.bridge.import_module",
+        lambda name: (
+            ExtractorsModule()
+            if name == "aniworld.extractors"
+            else ProviderModule()
+            if name == "aniworld.extractors.provider.voe"
+            else None
+        ),
+    )
+
+    resolved = resolve_via_aniworld(
+        module_name="voe",
+        function_name="get_direct_link_from_voe",
+        url="https://voe.sx/e/abc123",
+        host_name="VOE",
+    )
+
+    assert resolved == "https://voe.sx/e/abc123/registry"
+
+
 def test_resolve_via_aniworld_propagates_extractor_errors(monkeypatch):
     class ProviderModule:
         @staticmethod

--- a/apps/api/tests/unit/hosts/test_registry.py
+++ b/apps/api/tests/unit/hosts/test_registry.py
@@ -1,0 +1,13 @@
+from app.hosts import detect_host, resolve_host_url
+
+
+def test_detect_host_matches_known_embed_domain():
+    host = detect_host("https://voe.sx/e/abc123")
+    assert host is not None
+    assert host.name == "VOE"
+
+
+def test_resolve_host_url_returns_embed_when_unknown():
+    direct_url, host_name = resolve_host_url("https://example.invalid/embed/123")
+    assert direct_url is None
+    assert host_name == "EMBED"

--- a/apps/api/tests/unit/providers/megakino/test_sitemap.py
+++ b/apps/api/tests/unit/providers/megakino/test_sitemap.py
@@ -92,5 +92,5 @@ def test_megakino_resolve_direct_url_filters_speedfiles(monkeypatch):
         lambda html: ["https://speedfiles.example/embed/123"],
     )
 
-    with pytest.raises(ValueError, match="No provider iframes found"):
+    with pytest.raises(ValueError, match="No video host iframes found"):
         client.resolve_direct_url("slug")

--- a/apps/api/tests/unit/providers/megakino/test_sitemap.py
+++ b/apps/api/tests/unit/providers/megakino/test_sitemap.py
@@ -89,7 +89,7 @@ def test_megakino_resolve_direct_url_filters_speedfiles(monkeypatch):
         )(),
     )
     monkeypatch.setattr(
-        "app.providers.megakino.client._extract_provider_links",
+        "app.providers.megakino.client._extract_host_links",
         lambda html: ["https://speedfiles.example/embed/123"],
     )
 
@@ -118,7 +118,7 @@ def test_megakino_resolve_direct_url_warns_for_preferred_provider_alias(monkeypa
         )(),
     )
     monkeypatch.setattr(
-        "app.providers.megakino.client._extract_provider_links",
+        "app.providers.megakino.client._extract_host_links",
         lambda html: ["https://voe.sx/e/abc123"],
     )
     monkeypatch.setattr(
@@ -132,3 +132,40 @@ def test_megakino_resolve_direct_url_warns_for_preferred_provider_alias(monkeypa
 
     assert resolved == ("https://cdn.example/master.m3u8", "VOE")
     assert any(item.category is DeprecationWarning for item in caught)
+
+
+def test_megakino_resolve_direct_url_prefers_matching_host_domain(monkeypatch):
+    client = MegakinoClient(sitemap_url="http://example.com", refresh_hours=0.0)
+
+    monkeypatch.setattr(client, "resolve_url", lambda slug: "https://megakino1.to/page")
+    monkeypatch.setattr(
+        "app.providers.megakino.client.get_megakino_base_url",
+        lambda: "https://megakino1.to",
+    )
+    monkeypatch.setattr(
+        "app.providers.megakino.client._warm_megakino_session",
+        lambda base_url: None,
+    )
+    monkeypatch.setattr(
+        "app.providers.megakino.client.http_get",
+        lambda *args, **kwargs: type(
+            "Response",
+            (),
+            {"text": "<html></html>", "raise_for_status": lambda self: None},
+        )(),
+    )
+    monkeypatch.setattr(
+        "app.providers.megakino.client._extract_host_links",
+        lambda html: [
+            "https://streamtape.com/e/first",
+            "https://voe.sx/e/second",
+        ],
+    )
+    monkeypatch.setattr(
+        "app.providers.megakino.client.resolve_host_url",
+        lambda url: (None, "EMBED"),
+    )
+
+    resolved = client.resolve_direct_url("slug", preferred_host="https://voe.sx/embed")
+
+    assert resolved == ("https://voe.sx/e/second", "EMBED")

--- a/apps/api/tests/unit/providers/megakino/test_sitemap.py
+++ b/apps/api/tests/unit/providers/megakino/test_sitemap.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import warnings
 
 import pytest
 
@@ -94,3 +95,40 @@ def test_megakino_resolve_direct_url_filters_speedfiles(monkeypatch):
 
     with pytest.raises(ValueError, match="No video host iframes found"):
         client.resolve_direct_url("slug")
+
+
+def test_megakino_resolve_direct_url_warns_for_preferred_provider_alias(monkeypatch):
+    client = MegakinoClient(sitemap_url="http://example.com", refresh_hours=0.0)
+
+    monkeypatch.setattr(client, "resolve_url", lambda slug: "https://megakino1.to/page")
+    monkeypatch.setattr(
+        "app.providers.megakino.client.get_megakino_base_url",
+        lambda: "https://megakino1.to",
+    )
+    monkeypatch.setattr(
+        "app.providers.megakino.client._warm_megakino_session",
+        lambda base_url: None,
+    )
+    monkeypatch.setattr(
+        "app.providers.megakino.client.http_get",
+        lambda *args, **kwargs: type(
+            "Response",
+            (),
+            {"text": "<html></html>", "raise_for_status": lambda self: None},
+        )(),
+    )
+    monkeypatch.setattr(
+        "app.providers.megakino.client._extract_provider_links",
+        lambda html: ["https://voe.sx/e/abc123"],
+    )
+    monkeypatch.setattr(
+        "app.providers.megakino.client.resolve_host_url",
+        lambda url: ("https://cdn.example/master.m3u8", "VOE"),
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        resolved = client.resolve_direct_url("slug", preferred_provider="VOE")
+
+    assert resolved == ("https://cdn.example/master.m3u8", "VOE")
+    assert any(item.category is DeprecationWarning for item in caught)

--- a/internal/agents/architecture.md
+++ b/internal/agents/architecture.md
@@ -28,12 +28,16 @@
 
 - Jobs created in DB via `apps/api/app/db/models.create_job`.
 - `apps/api/app/core/scheduler` manages a thread pool respecting `MAX_CONCURRENCY`.
-- `apps/api/app/core/downloader` orchestrates provider fallback and progress updates.
+- `apps/api/app/core/downloader` orchestrates video-host fallback and progress updates.
+- `apps/api/app/hosts` wraps direct-video hosts (VOE, Filemoon, Streamtape,
+  Vidmoly, Doodstream, LoadX, Luluvdo, Vidoza, GXPlayer) separately from
+  catalogue-site providers.
 - Completion updates job and client task states for qBittorrent shim.
 
-## Download Pipeline and Providers
+## Download Pipeline and Video Hosts
 
-- Provider ordering is controlled by `PROVIDER_ORDER`.
+- Video-host ordering is controlled by `PROVIDER_ORDER` (internally exposed as
+  `VIDEO_HOST_ORDER` for clearer code-level naming).
 - Quality probing uses `apps/api/app/utils/probe_quality.py` (yt-dlp metadata).
 - Results stored under `DOWNLOAD_DIR`, optionally mapped to a public save path.
 - TTL cleanup removes old downloads when `DOWNLOADS_TTL_HOURS` > 0.

--- a/internal/agents/change-log.md
+++ b/internal/agents/change-log.md
@@ -1,5 +1,7 @@
 # Change Log
 
+- 2026-04-13: Documented the new `app/hosts` package and clarified the naming
+  split between catalogue-site providers and direct video hosts.
 - 2026-03-22: Documented automatic Serienstream Turnstile handling for protected
   `/r?t=...` redirect tokens, including browser-like headers and configurable
   backoff via `PROVIDER_CHALLENGE_BACKOFF_SECONDS`.

--- a/internal/agents/configuration.md
+++ b/internal/agents/configuration.md
@@ -7,13 +7,13 @@ AniBridge centralizes configuration in `apps/api/app/config.py`. Values are deri
 - Paths: `DATA_DIR`, `DOWNLOAD_DIR`, `QBIT_PUBLIC_SAVE_PATH`
 - Migrations: `DB_MIGRATE_ON_STARTUP`
 - Torznab: `INDEXER_NAME`, `INDEXER_API_KEY`, `TORZNAB_*`
-- Downloader: `PROVIDER_ORDER` (video-host priority), `PROVIDER_REDIRECT_TIMEOUT_SECONDS`,
+- Downloader: `PROVIDER_ORDER` (input env var, mapped at runtime to `VIDEO_HOST_ORDER`), `PROVIDER_REDIRECT_TIMEOUT_SECONDS`,
   `PROVIDER_REDIRECT_RETRIES`, `PROVIDER_CHALLENGE_BACKOFF_SECONDS`,
   `MAX_CONCURRENCY`, `DOWNLOAD_RATE_LIMIT_BYTES_PER_SEC`,
   `DOWNLOADS_TTL_HOURS`, `CLEANUP_SCAN_INTERVAL_MIN`
 - STRM: `STRM_FILES_MODE`, `STRM_PROXY_*`
 - Networking policy: external VPN/VPN-sidecar routing only + `PUBLIC_IP_CHECK_*`
-- Video-host order default: `VOE,Filemoon,Streamtape,Vidmoly,Doodstream,LoadX,Luluvdo,Vidoza`
+- Video-host order default: `VOE,Filemoon,Streamtape,Vidmoly,Doodstream,LoadX,Luluvdo,Vidoza` via `PROVIDER_ORDER`, mapped at runtime to `VIDEO_HOST_ORDER`
 - s.to/VOE note: if Sonarr shows `qBittorrent is reporting an error` for items
   that never started downloading, inspect logs for provider redirect timeouts and
   tune `PROVIDER_REDIRECT_TIMEOUT_SECONDS` / `PROVIDER_REDIRECT_RETRIES`
@@ -50,7 +50,7 @@ AniBridge centralizes configuration in `apps/api/app/config.py`. Values are deri
 21. `RELEASE_GROUP` — Release group label (default `aniworld`).
 22. `RELEASE_GROUP_ANIWORLD` — AniWorld release group override.
 23. `RELEASE_GROUP_STO` — s.to release group override.
-24. `PROVIDER_ORDER` — Comma-separated video-host priority list.
+24. `PROVIDER_ORDER` — Comma-separated video-host priority input; mapped at runtime to `VIDEO_HOST_ORDER`.
 25. `PROVIDER_REDIRECT_TIMEOUT_SECONDS` — Timeout for resolving catalogue redirect tokens into video-host URLs (default `12`).
 26. `PROVIDER_REDIRECT_RETRIES` — Extra retry attempts for transient video-host redirect failures (default `2`).
 27. `PROVIDER_CHALLENGE_BACKOFF_SECONDS` — Base cool-down for Turnstile challenge retries (default `300`).

--- a/internal/agents/configuration.md
+++ b/internal/agents/configuration.md
@@ -7,13 +7,13 @@ AniBridge centralizes configuration in `apps/api/app/config.py`. Values are deri
 - Paths: `DATA_DIR`, `DOWNLOAD_DIR`, `QBIT_PUBLIC_SAVE_PATH`
 - Migrations: `DB_MIGRATE_ON_STARTUP`
 - Torznab: `INDEXER_NAME`, `INDEXER_API_KEY`, `TORZNAB_*`
-- Downloader: `PROVIDER_ORDER`, `PROVIDER_REDIRECT_TIMEOUT_SECONDS`,
+- Downloader: `PROVIDER_ORDER` (video-host priority), `PROVIDER_REDIRECT_TIMEOUT_SECONDS`,
   `PROVIDER_REDIRECT_RETRIES`, `PROVIDER_CHALLENGE_BACKOFF_SECONDS`,
   `MAX_CONCURRENCY`, `DOWNLOAD_RATE_LIMIT_BYTES_PER_SEC`,
   `DOWNLOADS_TTL_HOURS`, `CLEANUP_SCAN_INTERVAL_MIN`
 - STRM: `STRM_FILES_MODE`, `STRM_PROXY_*`
 - Networking policy: external VPN/VPN-sidecar routing only + `PUBLIC_IP_CHECK_*`
-- Provider order default: `VOE,Filemoon,Streamtape,Vidmoly,Doodstream,LoadX,Luluvdo,Vidoza`
+- Video-host order default: `VOE,Filemoon,Streamtape,Vidmoly,Doodstream,LoadX,Luluvdo,Vidoza`
 - s.to/VOE note: if Sonarr shows `qBittorrent is reporting an error` for items
   that never started downloading, inspect logs for provider redirect timeouts and
   tune `PROVIDER_REDIRECT_TIMEOUT_SECONDS` / `PROVIDER_REDIRECT_RETRIES`
@@ -50,9 +50,9 @@ AniBridge centralizes configuration in `apps/api/app/config.py`. Values are deri
 21. `RELEASE_GROUP` — Release group label (default `aniworld`).
 22. `RELEASE_GROUP_ANIWORLD` — AniWorld release group override.
 23. `RELEASE_GROUP_STO` — s.to release group override.
-24. `PROVIDER_ORDER` — Comma-separated provider priority list.
-25. `PROVIDER_REDIRECT_TIMEOUT_SECONDS` — Timeout for resolving catalogue redirect tokens into provider URLs (default `12`).
-26. `PROVIDER_REDIRECT_RETRIES` — Extra retry attempts for transient provider redirect failures (default `2`).
+24. `PROVIDER_ORDER` — Comma-separated video-host priority list.
+25. `PROVIDER_REDIRECT_TIMEOUT_SECONDS` — Timeout for resolving catalogue redirect tokens into video-host URLs (default `12`).
+26. `PROVIDER_REDIRECT_RETRIES` — Extra retry attempts for transient video-host redirect failures (default `2`).
 27. `PROVIDER_CHALLENGE_BACKOFF_SECONDS` — Base cool-down for Turnstile challenge retries (default `300`).
 28. `MAX_CONCURRENCY` — Thread pool size (default `3`).
 29. `DOWNLOAD_RATE_LIMIT_BYTES_PER_SEC` — Per-download yt-dlp rate cap (`0` disables).

--- a/internal/agents/overview.md
+++ b/internal/agents/overview.md
@@ -26,7 +26,7 @@ AniBridge is a FastAPI service that bridges anime/series streaming catalogs (Ani
 | ORM/DB | SQLModel + SQLAlchemy | SQLite persistence for jobs and availability cache | `apps/api/app/db/models.py` |
 | Migrations | Alembic | Schema migration management | `apps/api/app/db/migrations/*`, `apps/api/alembic.ini` |
 | Background Jobs | ThreadPoolExecutor | Download orchestration, TTL cleanup, IP monitor | `apps/api/app/core/scheduler.py`, `apps/api/app/core/lifespan.py` |
-| Downloader | yt-dlp, AniWorld lib | Episode retrieval and provider fallback | `apps/api/app/core/downloader/*` |
+| Downloader | yt-dlp, AniWorld lib | Episode retrieval and video-host fallback | `apps/api/app/core/downloader/*`, `apps/api/app/hosts/*` |
 | Logging | Loguru | Structured logs and file mirroring | `apps/api/app/utils/logger.py`, `apps/api/app/infrastructure/terminal_logger.py` |
 | Configuration | dotenv + env vars | Centralized config resolution | `apps/api/app/config.py` |
 | Docs Site | VitePress | Static documentation | `docs/.vitepress/*`, `docs/src/*` |

--- a/internal/agents/repo-map.md
+++ b/internal/agents/repo-map.md
@@ -27,8 +27,9 @@
 
 - `api/` — endpoint routers grouped by domain.
 - `core/` — bootstrap, scheduler, downloader, lifespan.
+- `hosts/` — direct-video host wrappers and extraction registry.
 - `core/downloader/extractors/` — local extractor overrides for fragile
-  upstream provider logic such as VOE.
+  upstream host logic such as VOE.
 - `db/` — SQLModel definitions and helpers.
 - `domain/` — domain-level models.
 - `infrastructure/` — logging, networking helpers, system diagnostics.
@@ -67,6 +68,7 @@
 - `apps/api/app/core/lifespan.py` — FastAPI lifespan manager.
 - `apps/api/app/core/scheduler.py` — thread pool management.
 - `apps/api/app/core/downloader/*` — download orchestration.
+- `apps/api/app/hosts/*` — direct-video host wrappers and registry.
 - `apps/api/app/api/health.py` — health check router.
 - `apps/api/app/api/legacy_downloader.py` — legacy download endpoint.
 - `apps/api/app/api/torznab/api.py` — Torznab handlers.

--- a/internal/agents/testing.md
+++ b/internal/agents/testing.md
@@ -17,8 +17,9 @@
 - `tests/unit/api/` contains non-request unit coverage for API helper modules.
 - `tests/unit/core/` groups downloader, scheduler, and STRM proxy logic.
 - `tests/unit/db/` covers SQLModel behavior and Alembic migrations.
-- `tests/unit/providers/` groups provider-specific logic by source
+- `tests/unit/providers/` groups catalogue-site-specific logic by source
   (`aniworld`, `megakino`, `sto`).
+- `tests/unit/hosts/` covers direct-video host detection and wrapper behavior.
 - `tests/unit/scripts/` covers repository automation scripts.
 - `tests/unit/utils/` contains utility coverage, including nested
   `title_resolver/` tests.


### PR DESCRIPTION
## Description

This pull request introduces a major refactor to the handling of video providers, separating the concepts of catalogue sites ("providers") and direct video hosts. The codebase now uses a new `VideoHost` abstraction for all direct video streaming platforms, centralizing their configuration and resolution logic under `apps/api/app/hosts/`. This change improves clarity, maintainability, and extensibility for handling video hosts and their direct URL extraction.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Testing

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

## Additional Notes

**Key changes:**

### 1. Video Host Abstraction and Centralization

- Introduced a new `VideoHost` dataclass and related logic in `apps/api/app/hosts/`, with one module per supported host (e.g., `voe`, `filemoon`, `doodstream`, etc.). Each host module provides canonical naming, URL matching hints, and a resolver function for direct link extraction. (`apps/api/app/hosts/base.py` [[1]](diffhunk://#diff-8f0d5f651d58c7597c6da46758770eedbf248314369f7d49a8e422f3b1034518R1-R28) `apps/api/app/hosts/__init__.py` [[2]](diffhunk://#diff-d893a03552f33079c49d0f52bf924eed56469fa881f5e6292068441c8452f27eR1-R63) plus new host modules [[3]](diffhunk://#diff-f82a6a0ef569295ed0ece85077fa68d3cf62248d1d7fcd250f5e3ae3b609eaf1R1-R16) [[4]](diffhunk://#diff-79eef7fd48041f40d44f388aaaa937d5486a34409f8583eaee89dc232768888dR1-R16) [[5]](diffhunk://#diff-1c6bdae65b7b6dec115c6f2f5d9060722c6a3aab75d196a12c3b3a1c3a00594fR1-R46) [[6]](diffhunk://#diff-20beb1df7865ca26d936d4df315e378e6fc31964ddd5e32c4b1b13d19c89797dR1-R16) [[7]](diffhunk://#diff-d8e01b4bd0abdebc343c578efde83f082b7c131f52fd5b1019cf45662ca2b1f7R1-R16) [[8]](diffhunk://#diff-ac3cf86b7181427f6f7b2d52662fd7236fbafab7a9a196650d895223d0e190fdR1-R16) [[9]](diffhunk://#diff-063833250886d9120d901f99baac4c64721031147d51142ec1ee195b39cec85eR1-R16) [[10]](diffhunk://#diff-19ead478bb5475dc7184958bf806cb57b0176d23fdb86e097b0175b1c0b5b9efR1-R16) [[11]](diffhunk://#diff-7c9506bb957ce18541164836f0ee8c66f9a024f391f491c284ee2a1b12f973daR1-R16)
- Added a bridge module to support extraction via upstream aniworld extractors, with fallback logic. (`apps/api/app/hosts/bridge.py` [apps/api/app/hosts/bridge.pyR1-R41](diffhunk://#diff-9ff61027ce24181cb3119bb27ffb1006867f1233b5d605188eae8b125402660dR1-R41))

### 2. Terminology and API Changes

- Replaced the ambiguous use of "provider" with "video host" throughout the downloader and configuration code, both in function parameters and documentation. (`apps/api/app/core/downloader/download.py` [[1]](diffhunk://#diff-8dfa75e1bbd6a0e92f5b2718438ffb3ab4150dbde3a07c9ba6b9d725a7104513L34-R37) [[2]](diffhunk://#diff-8dfa75e1bbd6a0e92f5b2718438ffb3ab4150dbde3a07c9ba6b9d725a7104513L100-R118) [[3]](diffhunk://#diff-8dfa75e1bbd6a0e92f5b2718438ffb3ab4150dbde3a07c9ba6b9d725a7104513L156-R165) `apps/api/app/core/downloader/provider_resolution.py` [[4]](diffhunk://#diff-53b692f8d1f3ca289de03987e758cc841eb9c97849a56622433344e5c397582fL166-R166) `apps/api/app/config.py` [[5]](diffhunk://#diff-5111164e3eb30f95f27986023ae95aa661a46357f713d8b13c7f7d7898c0819fL300-R313) [[6]](diffhunk://#diff-5111164e3eb30f95f27986023ae95aa661a46357f713d8b13c7f7d7898c0819fL320-R328) `apps/api/app/core/strm_proxy/resolver.py` [[7]](diffhunk://#diff-19d909bb3df8e656181521a2cc8f0a0ea1de7737ceed1a0eaae9f0d19e3a09a9L40-R40)
- Updated the documentation and code comments to clarify that "providers/" refers to catalogue sites, while direct video hosts are under `hosts/`. (`AGENTS.md` [AGENTS.mdR13-R15](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R13-R15))

### 3. Type System and Backwards Compatibility

- Defined a new `Host` type for video host identifiers, and aliased the old `Provider` type to `Host` for backwards compatibility. (`apps/api/app/core/downloader/types.py` [[1]](diffhunk://#diff-003ef1f59f24c6477e1b2317bb2b728d256b50bf53f46484c9e7967abfacf0a6L7-R8) [[2]](diffhunk://#diff-003ef1f59f24c6477e1b2317bb2b728d256b50bf53f46484c9e7967abfacf0a6R18-R19)
- Updated imports and exports to include the new `Host` type. (`apps/api/app/core/downloader/__init__.py` [apps/api/app/core/downloader/__init__.pyL9-R14](diffhunk://#diff-ce7fa99db105988f55b177f0220b8a1265071b8a4bccbdeb411b7fdffe895453L9-R14))

### 4. Refactoring Direct Link Resolution

- All direct URL resolution now goes through the `VideoHost` abstraction, using `get_host` to look up the appropriate host and its resolver. (`apps/api/app/core/downloader/episode.py` [[1]](diffhunk://#diff-10b90be67195ca7ca98318d307ac148eebad273b87ba646db4fc8e9d883e4e0eR16) [[2]](diffhunk://#diff-10b90be67195ca7ca98318d307ac148eebad273b87ba646db4fc8e9d883e4e0eL406-R422)

---

These changes lay the groundwork for easier addition of new video hosts and more robust, explicit handling of direct streaming platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified video-host registry and individual host integrations (including GXPlayer) for broader direct-link support and more reliable resolution.
  * Introduced host detection utilities and URL resolvers to improve automatic host selection and fallback.

* **Bug Fixes**
  * Clarified and improved error/warning messages around host resolution and fallback behavior.

* **Tests**
  * Added unit tests covering host detection, resolution, GXPlayer handling, and related fallback/deprecation paths.

* **Documentation**
  * Updated docs to distinguish catalogue providers from direct video hosts and document host ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->