### PR TITLE
fix(release): update latest tag and Gluetun ports

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -394,6 +394,7 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.publish-ref.outputs.next_version }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.publish-ref.outputs.release_tag }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false

--- a/docker/compose.dev.vpn.yaml
+++ b/docker/compose.dev.vpn.yaml
@@ -10,10 +10,11 @@ services:
       dockerfile: apps/api/Dockerfile
     container_name: anibridge-dev-vpn
     env_file:
-    # You will need to set port to something other than 8000 in the .env file since this is already used in this stack
       - ../.env
     environment:
       - ANIBRIDGE_RELOAD=true
+      # Gluetun's control server already listens on port 8000 in this namespace.
+      - ANIBRIDGE_PORT=8001
       - DATA_DIR=/data
       - DOWNLOAD_DIR=/downloads
     volumes:
@@ -46,7 +47,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl --fail --silent \"http://localhost:${ANIBRIDGE_PORT:-8000}/health\" >/dev/null && curl --fail --silent https://1.1.1.1 >/dev/null",
+          "curl --fail --silent \"http://localhost:${ANIBRIDGE_PORT:-8001}/health\" >/dev/null && curl --fail --silent https://1.1.1.1 >/dev/null",
         ]
       interval: 30s
       timeout: 5s

--- a/docs/src/guide/networking.md
+++ b/docs/src/guide/networking.md
@@ -30,6 +30,11 @@ services:
       - ANIBRIDGE_HOST=0.0.0.0
       # Gluetun's control server already uses port 8000 in this namespace.
       - ANIBRIDGE_PORT=8001
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "http://localhost:8001/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
 ```
 
 ## Public IP Monitor

--- a/docs/src/guide/networking.md
+++ b/docs/src/guide/networking.md
@@ -21,14 +21,15 @@ services:
   gluetun:
     image: qmcgaw/gluetun:latest
     ports:
-      - "8000:8000/tcp"
+      - "8001:8001/tcp"
 
   anibridge:
     image: ghcr.io/zzackllack/anibridge:latest
     network_mode: "service:gluetun"
     environment:
       - ANIBRIDGE_HOST=0.0.0.0
-      - ANIBRIDGE_PORT=8000
+      # Gluetun's control server already uses port 8000 in this namespace.
+      - ANIBRIDGE_PORT=8001
 ```
 
 ## Public IP Monitor

--- a/docs/src/guide/quickstart.md
+++ b/docs/src/guide/quickstart.md
@@ -92,6 +92,11 @@ services:
     volumes:
       - ./downloads:/data/downloads
       - ./data:/data
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "http://localhost:8001/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
 ```
 
 ::: warning Port collisions inside VPN namespace

--- a/docs/src/guide/quickstart.md
+++ b/docs/src/guide/quickstart.md
@@ -72,7 +72,7 @@ services:
     container_name: gluetun
     cap_add: ["NET_ADMIN"]
     ports:
-      - "8000:8000/tcp"   # expose AniBridge through the VPN container
+      - "8001:8001/tcp"   # expose AniBridge through the VPN container
     environment:
       # Fill according to the Gluetun docs for your provider
       - VPN_SERVICE_PROVIDER=custom     # or your provider name
@@ -86,6 +86,8 @@ services:
     container_name: anibridge
     network_mode: "service:gluetun"   # route all traffic via Gluetun
     environment:
+      # Gluetun's control server already uses port 8000 in this namespace
+      - ANIBRIDGE_PORT=8001
       - QBIT_PUBLIC_SAVE_PATH=/downloads
     volumes:
       - ./downloads:/data/downloads
@@ -93,7 +95,10 @@ services:
 ```
 
 ::: warning Port collisions inside VPN namespace
-When multiple apps share Gluetun’s network, each must listen on a unique internal port. AniBridge defaults to `8000`. If you need a different port, set `ANIBRIDGE_PORT` and map the same port on the Gluetun service.
+Gluetun's HTTP control server listens on port `8000` by default. Containers
+sharing Gluetun's network namespace cannot also bind that port, so the example
+configures AniBridge to use `8001`. Every app sharing the namespace must listen
+on a unique internal port.
 :::
 
 ## Option B — Bare metal (prebuilt releases)


### PR DESCRIPTION
## Description

This pull request updates the default port configuration for AniBridge when running behind Gluetun to avoid a port collision, and ensures that documentation and health checks are consistent with the new port. It also adds a `latest` tag to the image publishing workflow. See #130

**Port configuration updates (to avoid collision with Gluetun):**

* Changed AniBridge's default port to `8001` instead of `8000` in `docker/compose.dev.vpn.yaml` and updated the healthcheck to use the new port. [[1]](diffhunk://#diff-ea3d3eb227b306a42c878bbeaf5d68b15775651e5fd40185e533ec4981b9d13fL13-R17) [[2]](diffhunk://#diff-ea3d3eb227b306a42c878bbeaf5d68b15775651e5fd40185e533ec4981b9d13fL49-R50)
* Updated documentation in `docs/src/guide/networking.md` and `docs/src/guide/quickstart.md` to use port `8001` for AniBridge and clarified the reason for the change in comments and warnings. [[1]](diffhunk://#diff-715fc9ad05515960d3c4c81e52e6873524c3cb6ae2c73ff8484876855d43e2afL24-R32) [[2]](diffhunk://#diff-9a77c1208aff91424068c2b6a9690882d0238609eada7f439d68f27c0016aef3L75-R75) [[3]](diffhunk://#diff-9a77c1208aff91424068c2b6a9690882d0238609eada7f439d68f27c0016aef3R89-R101)

**CI/CD improvements:**

* Added the `latest` tag to the image in the release workflow (`.github/workflows/cut-release.yml`) to ensure the most recent image is always available.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Testing

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

## Additional Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow now also publishes a `latest` image tag alongside existing versioned tags.

* **Documentation**
  * Docker + Gluetun guides updated to show AniBridge on port 8001 and warn about Gluetun’s control server using port 8000 to avoid internal port conflicts.

* **Configuration**
  * Development Compose configuration set AniBridge to port 8001 and adjusted its healthcheck to match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->