### PR TITLE
fix(aniworld/torznab): restore English Sub/Dub releases (language decoder + specials-mapping guard)

### DIFF
--- a/apps/api/app/api/torznab/tvsearch.py
+++ b/apps/api/app/api/torznab/tvsearch.py
@@ -502,26 +502,55 @@ def emit_tvsearch_episode_items(
                 ):
                     if not special_map_attempted:
                         special_map_attempted = True
-                        special_map = resolve_special_mapping_from_episode_request_fn(
-                            slug=slug,
-                            request_season=request_season,
-                            request_episode=request_episode,
-                            query=q_str,
-                            series_title=display_title,
-                            ids=ids,
+                        # Guard against hijacking a normal episode: an episode
+                        # that merely lacks the first probed language (e.g. no
+                        # German Dub, but English/German Sub present) must NOT be
+                        # remapped to a season-0 film. Only treat the request as a
+                        # special when the real requested episode advertises no
+                        # languages at all (i.e. it has no normal page).
+                        real_languages = (
+                            discover_episode_languages_for_fast_season_mode_fn(
+                                slug=slug,
+                                season_i=request_season,
+                                episode_i=request_episode,
+                                site_found=site_found,
+                            )
                         )
-                        if special_map is not None:
+                        if real_languages:
                             logger.info(
                                 (
-                                    "Special mapping (tvsearch) resolved: slug={} "
-                                    "requested=S{}E{} target=S{}E{}"
+                                    "Skipping special mapping for slug={} S{}E{}: "
+                                    "real episode advertises languages {} "
+                                    "(treating as a normal episode)."
                                 ),
                                 slug,
                                 request_season,
                                 request_episode,
-                                special_map.source_season,
-                                special_map.source_episode,
+                                real_languages,
                             )
+                        else:
+                            special_map = (
+                                resolve_special_mapping_from_episode_request_fn(
+                                    slug=slug,
+                                    request_season=request_season,
+                                    request_episode=request_episode,
+                                    query=q_str,
+                                    series_title=display_title,
+                                    ids=ids,
+                                )
+                            )
+                            if special_map is not None:
+                                logger.info(
+                                    (
+                                        "Special mapping (tvsearch) resolved: slug={} "
+                                        "requested=S{}E{} target=S{}E{}"
+                                    ),
+                                    slug,
+                                    request_season,
+                                    request_episode,
+                                    special_map.source_season,
+                                    special_map.source_episode,
+                                )
                     if special_map is not None:
                         (
                             available,

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -266,7 +266,7 @@ _DEFAULT_SITE_CONFIGS: dict[str, dict[str, Any]] = {
         "alphabet_html": ANIWORLD_ALPHABET_HTML,
         "alphabet_url": ANIWORLD_ALPHABET_URL,
         "titles_refresh_hours": ANIWORLD_TITLES_REFRESH_HOURS,
-        "default_languages": ["German Dub", "German Sub", "English Sub"],
+        "default_languages": ["German Dub", "German Sub", "English Sub", "English Dub"],
         "release_group": RELEASE_GROUP_ANIWORLD,
     },
     "s.to": {

--- a/apps/api/app/core/downloader/episode.py
+++ b/apps/api/app/core/downloader/episode.py
@@ -252,6 +252,49 @@ def _extract_season_episode_from_link(link: str, site: str) -> tuple[int, int]:
     )
 
 
+def _label_from_lang_tuple(key: Any) -> Optional[str]:
+    """
+    Decode an aniworld>=4 ``(Audio, Subtitles)`` language key into a canonical label.
+
+    The backend exposes each language variant as a two-element key whose elements are
+    enum-like members with a ``.value`` (e.g. ``"German"``/``"English"``/``"None"``); raw
+    strings or ints are tolerated too. The canonical labels returned here ("German Dub",
+    "English Dub", "German Sub", "English Sub") match the values used in config defaults,
+    ``language.py`` and the s.to provider.
+
+    This is the resilient fallback for when the upstream ``INVERSE_LANG_KEY_MAP`` /
+    ``LANG_LABELS`` lookup does not recognise a key (which silently drops English variants).
+
+    Returns:
+        The canonical label, or ``None`` when the key shape/values cannot be mapped.
+    """
+    if not (isinstance(key, tuple) and len(key) == 2):
+        return None
+    audio = str(getattr(key[0], "value", key[0])).strip().lower()
+    subtitles = str(getattr(key[1], "value", key[1])).strip().lower()
+
+    def _is_german(value: str) -> bool:
+        return value.startswith("german") or value in ("deutsch", "de", "ger")
+
+    def _is_english(value: str) -> bool:
+        return value.startswith("english") or value in ("englisch", "en", "eng")
+
+    # No subtitle overlay -> the audio track defines a "Dub".
+    if subtitles in ("", "none", "0"):
+        if _is_german(audio):
+            return "German Dub"
+        if _is_english(audio):
+            return "English Dub"
+        return None
+
+    # A subtitle overlay -> the subtitle language defines a "Sub".
+    if _is_german(subtitles):
+        return "German Sub"
+    if _is_english(subtitles):
+        return "English Sub"
+    return None
+
+
 @dataclass(slots=True)
 class EpisodeCompat:
     """Compatibility shim for aniworld>=4 site-specific episode classes."""
@@ -289,6 +332,11 @@ class EpisodeCompat:
                 try:
                     label = LANG_LABELS[INVERSE_LANG_KEY_MAP[key]]
                 except KeyError:
+                    # The upstream maps don't recognise this key (commonly the
+                    # case for English variants after site/library drift); decode
+                    # the (Audio, Subtitles) tuple directly instead of dropping it.
+                    label = _label_from_lang_tuple(key)
+                if not label:
                     logger.debug(
                         "Skipping unknown aniworld language tuple in compatibility layer: {}",
                         key,
@@ -300,15 +348,8 @@ class EpisodeCompat:
             return labels
 
         for key in raw.keys():
-            if not isinstance(key, tuple) or len(key) != 2:
-                continue
-            audio = getattr(key[0], "value", None)
-            subtitles = getattr(key[1], "value", None)
-            if audio == "German" and subtitles == "None":
-                label = "German Dub"
-            elif audio == "English" and subtitles == "None":
-                label = "English Dub"
-            else:
+            label = _label_from_lang_tuple(key)
+            if not label:
                 continue
             if label not in seen:
                 seen.add(label)
@@ -326,11 +367,23 @@ class EpisodeCompat:
         from aniworld.config import INVERSE_LANG_LABELS, LANG_KEY_MAP  # type: ignore
 
         key = INVERSE_LANG_LABELS.get(language)
-        if key is None:
-            raise ValueError(
-                f"Invalid language: {language}. Valid options for {self.site}: {self.available_languages}"
-            )
-        return LANG_KEY_MAP[key]
+        if key is not None:
+            return LANG_KEY_MAP[key]
+
+        # The upstream label maps don't know this canonical label (e.g. an English
+        # variant surfaced only via the tuple-decode fallback). Resolve it against
+        # the raw provider data instead; _get_provider_redirect_url matches raw
+        # (Audio, Subtitles) tuples by value, so returning the raw key works.
+        provider_data = getattr(self._backend, "provider_data", None)
+        raw = getattr(provider_data, "_data", provider_data)
+        if isinstance(raw, dict):
+            for raw_key in raw.keys():
+                if _label_from_lang_tuple(raw_key) == language:
+                    return raw_key
+
+        raise ValueError(
+            f"Invalid language: {language}. Valid options for {self.site}: {self.available_languages}"
+        )
 
     def _get_provider_redirect_url(self, language: Any, provider_name: str) -> str:
         provider_data = getattr(self._backend, "provider_data", None)

--- a/apps/api/tests/unit/core/downloader/test_episode.py
+++ b/apps/api/tests/unit/core/downloader/test_episode.py
@@ -112,6 +112,178 @@ def test_build_episode_supports_aniworld_v4_api(monkeypatch):
     )
 
 
+def test_aniworld_available_languages_recovers_unmapped_english(monkeypatch):
+    """
+    Regression for the reported bug: English Sub/Dub vanished from Sonarr while German remained.
+
+    Simulates AniWorld serving four language variants where only "German Dub" is present in the
+    upstream ``INVERSE_LANG_KEY_MAP``/``LANG_LABELS`` (the English and subtitle keys have drifted
+    out). The hardened ``available_languages`` must recover the English/subtitle variants via the
+    direct tuple decode instead of silently dropping them, and the download path must resolve a
+    language that is only known via that fallback.
+    """
+    import importlib
+    import sys
+    import types
+    from enum import Enum
+
+    class Audio(Enum):
+        GERMAN = "German"
+        ENGLISH = "English"
+        JAPANESE = "Japanese"
+
+    class Subtitles(Enum):
+        NONE = "None"
+        GERMAN = "German"
+        ENGLISH = "English"
+
+    german_dub = (Audio.GERMAN, Subtitles.NONE)
+    english_dub = (Audio.ENGLISH, Subtitles.NONE)
+    german_sub = (Audio.JAPANESE, Subtitles.GERMAN)
+    english_sub = (Audio.JAPANESE, Subtitles.ENGLISH)
+
+    class FakeSession:
+        def get(self, url: str, **_kwargs):
+            return types.SimpleNamespace(url=f"{url}/resolved")
+
+    class FakeAniworldEpisode:
+        def __init__(self, *, url: str):
+            self.url = url
+            self.provider_data = types.SimpleNamespace(
+                _data={
+                    german_dub: {"VOE": "https://aniworld.to/r/de-dub"},
+                    english_dub: {"VOE": "https://aniworld.to/r/en-dub"},
+                    german_sub: {"VOE": "https://aniworld.to/r/de-sub"},
+                    english_sub: {"VOE": "https://aniworld.to/r/en-sub"},
+                }
+            )
+
+    fake_models = types.ModuleType("aniworld.models")
+    fake_models.AniworldEpisode = FakeAniworldEpisode
+    fake_models.SerienstreamEpisode = FakeAniworldEpisode
+
+    fake_config = types.ModuleType("aniworld.config")
+    fake_config.GLOBAL_SESSION = FakeSession()
+    # Only German Dub is known to the upstream maps; the English and subtitle keys
+    # are deliberately absent to reproduce the silent-drop that hid them from Sonarr.
+    fake_config.LANG_KEY_MAP = {"1": german_dub}
+    fake_config.LANG_LABELS = {"1": "German Dub"}
+    fake_config.INVERSE_LANG_LABELS = {"German Dub": "1"}
+    fake_config.INVERSE_LANG_KEY_MAP = {german_dub: "1"}
+
+    fake_extractors = types.ModuleType("aniworld.extractors")
+    fake_extractors.provider_functions = {
+        "get_direct_link_from_voe": lambda url: f"{url}/master.m3u8"
+    }
+
+    monkeypatch.setitem(sys.modules, "aniworld.models", fake_models)
+    monkeypatch.setitem(sys.modules, "aniworld.config", fake_config)
+    monkeypatch.setitem(sys.modules, "aniworld.extractors", fake_extractors)
+
+    original_episode_module = sys.modules.get("app.core.downloader.episode")
+    sys.modules.pop("app.core.downloader.episode", None)
+    episode_module = importlib.import_module("app.core.downloader.episode")
+    if original_episode_module is not None:
+        monkeypatch.setitem(
+            sys.modules, "app.core.downloader.episode", original_episode_module
+        )
+    patch_voe_resolver(monkeypatch, episode_module)
+
+    episode = episode_module.build_episode(
+        slug="kaguya-sama-love-is-war",
+        season=1,
+        episode=1,
+        site="aniworld.to",
+    )
+
+    assert set(episode.available_languages) == {
+        "German Dub",
+        "English Dub",
+        "German Sub",
+        "English Sub",
+    }
+    # End-to-end: a variant unknown to the upstream label maps still resolves for download.
+    assert (
+        episode.get_direct_link("VOE", "English Sub")
+        == "https://aniworld.to/r/en-sub/resolved/master.m3u8"
+    )
+
+
+def test_sto_available_languages_includes_subtitle_variants(monkeypatch):
+    """
+    s.to previously emitted only Dub variants (it required ``subtitles == "None"``), dropping
+    every subtitle variant. After sharing the tuple decoder, German Sub / English Sub must surface.
+    """
+    import importlib
+    import sys
+    import types
+    from enum import Enum
+
+    class Audio(Enum):
+        GERMAN = "German"
+        JAPANESE = "Japanese"
+
+    class Subtitles(Enum):
+        NONE = "None"
+        GERMAN = "German"
+        ENGLISH = "English"
+
+    german_dub = (Audio.GERMAN, Subtitles.NONE)
+    german_sub = (Audio.JAPANESE, Subtitles.GERMAN)
+    english_sub = (Audio.JAPANESE, Subtitles.ENGLISH)
+
+    class FakeSession:
+        def get(self, url: str, **_kwargs):
+            return types.SimpleNamespace(url=f"{url}/resolved")
+
+    class FakeStoEpisode:
+        def __init__(self, *, url: str):
+            self.url = url
+            self.provider_data = {
+                german_dub: {"VOE": "https://s.to/r/de-dub"},
+                german_sub: {"VOE": "https://s.to/r/de-sub"},
+                english_sub: {"VOE": "https://s.to/r/en-sub"},
+            }
+
+    fake_models = types.ModuleType("aniworld.models")
+    fake_models.AniworldEpisode = FakeStoEpisode
+    fake_models.SerienstreamEpisode = FakeStoEpisode
+
+    fake_config = types.ModuleType("aniworld.config")
+    fake_config.GLOBAL_SESSION = FakeSession()
+
+    fake_extractors = types.ModuleType("aniworld.extractors")
+    fake_extractors.provider_functions = {
+        "get_direct_link_from_voe": lambda url: f"{url}/master.m3u8"
+    }
+
+    monkeypatch.setitem(sys.modules, "aniworld.models", fake_models)
+    monkeypatch.setitem(sys.modules, "aniworld.config", fake_config)
+    monkeypatch.setitem(sys.modules, "aniworld.extractors", fake_extractors)
+
+    original_episode_module = sys.modules.get("app.core.downloader.episode")
+    sys.modules.pop("app.core.downloader.episode", None)
+    episode_module = importlib.import_module("app.core.downloader.episode")
+    if original_episode_module is not None:
+        monkeypatch.setitem(
+            sys.modules, "app.core.downloader.episode", original_episode_module
+        )
+    patch_voe_resolver(monkeypatch, episode_module)
+
+    episode = episode_module.build_episode(
+        slug="9-1-1",
+        season=1,
+        episode=5,
+        site="s.to",
+    )
+
+    assert set(episode.available_languages) == {
+        "German Dub",
+        "German Sub",
+        "English Sub",
+    }
+
+
 def test_build_episode_supports_sto_v4_api(monkeypatch):
     import importlib
     import sys


### PR DESCRIPTION
## Summary
Restores English Sub/Dub anime releases that stopped appearing in Sonarr. Two independent root causes are fixed, plus a defaults safety net. Verified live against a dev stack (aniworld v4, `aniworld==4.2.1`).

## 1. Language decoder silently dropped English variants
For `aniworld.to`, `EpisodeCompat.available_languages` mapped each `(Audio, Subtitles)` key **only** through the upstream `INVERSE_LANG_KEY_MAP` / `LANG_LABELS`, and `continue`d on `KeyError` — silently dropping any English key the maps didn't recognise, so only German reached Sonarr. The `s.to` branch had a parallel bug: it only emitted Dub variants (`subtitles == "None"`), dropping all Sub variants.

**Fix:** a shared `_label_from_lang_tuple()` helper decodes the tuple directly into the canonical labels (German/English Dub/Sub). aniworld falls back to it on `KeyError`; s.to reuses it; `_normalize_language_for_backend` gets a matching inverse fallback so a recovered label still resolves for download. `"English Dub"` added to the aniworld defaults as a safety net.

## 2. Specials-mapping hijacked real episodes
Episode searches probe languages in the default order, which starts with `German Dub`. For an episode that lacks German Dub (sub-only), the first probe "failed", the code assumed the episode was a special, and remapped the real episode (e.g. S4E10) to a season-0 film (S0E2) that was German-only — burying the real episode's English Sub.

**Fix:** before remapping to a special, check whether the real requested episode advertises any languages; if it does, treat it as a normal episode and skip special-mapping. Genuine specials (episodes with no normal page) still map.

## Tests
- `test_aniworld_available_languages_recovers_unmapped_english`
- `test_sto_available_languages_includes_subtitle_variants`

`cd apps/api && uv run pytest tests/unit/core/downloader/test_episode.py`

## Live verification (dev stack)
- aniworld `S4E10` feed now emits `GER.SUB` **and** `ENG.SUB` for the real episode (magnet `aw_s=4&aw_e=10`); log shows `Skipping special mapping ... treating as a normal episode`.
- `Arifureta` S2E11 (has English on AniWorld) emits `ENG.SUB`; S2E12 is correctly German-only (verified against the raw AniWorld page HTML — episode 12 has no English key yet).

## Out of scope (deferred)
- Cross-site routing: a romaji query can resolve to `s.to`, which may lack Sub variants for a title.
- One video host per release is intentional (automatic fallback across hosts happens at download time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * English Dub is now available as a default option for aniworld.to content

* **Bug Fixes**
  * Improved language variant detection for unmapped audio and subtitle combinations, ensuring variants like English Sub and German Sub are properly recognized
  * Enhanced special episode mapping with more intelligent fallback detection

* **Tests**
  * Added test coverage for language variant recovery and subtitle inclusion across multiple providers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->